### PR TITLE
Win32 idle responsiveness fix

### DIFF
--- a/DtCyber.vcxproj
+++ b/DtCyber.vcxproj
@@ -116,7 +116,7 @@
       <Culture>0x0409</Culture>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>odbc32.lib;odbccp32.lib;ws2_32.lib;setupapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>winmm.lib;odbc32.lib;odbccp32.lib;ws2_32.lib;setupapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <GenerateMapFile>true</GenerateMapFile>
       <SubSystem>Console</SubSystem>

--- a/main.c
+++ b/main.c
@@ -46,6 +46,7 @@
 #if defined(_WIN32)
 #include <Windows.h>
 #include <winsock.h>
+#include <timeapi.h>
 #else
 #include <signal.h>
 #include <unistd.h>
@@ -136,7 +137,7 @@ int main(int argc, char **argv)
     **  Pause for user upon exit so display doesn't disappear
     */
     atexit(opExit);
-
+    timeBeginPeriod(8);
     /*
     **  Select WINSOCK 1.1.
     */
@@ -671,7 +672,7 @@ static void INThandler(int sig)
 static void opExit()
     {
     char check;
-
+    timeEndPeriod(8);
     if (_isatty(_fileno(stdin)))
         {
         printf("Press ENTER to Exit");


### PR DESCRIPTION
This should improve overall performance of the emulator when the idle throttle runs under WIndows by making sure we wake up from Sleep() earlier by requesting a higher timer resolution for the process via a timeBeginPeriod() API call. 