### PR TITLE
Remove need to restart NAM during CYBIS install.

### DIFF
--- a/NOS2.8.7/opt/cybis.post
+++ b/NOS2.8.7/opt/cybis.post
@@ -11,7 +11,6 @@ dtc.connect()
 .then(() => dtc.say("idle IAF"))
 .then(() => dtc.dsd([
 "IDLE,IAF.",
-"IDLE,NAM.",
 "SUB."]))
 .then(() => dtc.sleep(2000))
 .then(() => dtc.dsd([
@@ -27,9 +26,6 @@ dtc.connect()
     "ATTACH(CYBBIN)",
     "SYSEDIT(B=CYBBIN,L=OUTPUT)"
 ], "CYBSE", 1))
-.then(() => dtc.say("Starting NAM"))
-.then(() => dtc.dsd(["NA."]))
-.then(() => dtc.sleep(20000))
 .then(() => dtc.say("Starting CYBIS ..."))
 .then(() => dtc.dsd(["CYBIS."]))
 .then(() => dtc.sleep(20000))

--- a/NOS2.8.7/opt/products.json
+++ b/NOS2.8.7/opt/products.json
@@ -57,6 +57,8 @@
       {
         "name": "cybis",
         "pre": [
+          "cybis-ndl.job",
+          "../decks/compile-ndlopl.job",
           "cybis-eqpd.job",
           "../make-ds-tape.js",
           "cybis-newds.pre",
@@ -64,8 +66,6 @@
           "cybis-start.pre",
           "cybis-users.job",
           "cybis-users.pre",
-          "cybis-ndl.job",
-          "../decks/compile-ndlopl.job",
           "cybis-mount-bin.pre"
         ],
         "post": [


### PR DESCRIPTION
Remove the neeed to restart NAM by moving the NDL configuration step to the beginning of the CYBIS install steps, this will make NAM ready for CYBIS connections by the time we re-deadstart with the new equipment deck early on in the process.