### PR TITLE
Remove ~eor from 0PIMSFX.mod

### DIFF
--- a/NOS2.8.7/mods/NOS/0PIMSFX.mod
+++ b/NOS2.8.7/mods/NOS/0PIMSFX.mod
@@ -43,4 +43,3 @@
           LDM    FSN  SET FACTORY SECTOR NUMBER
           STD    T7 
 */        END OF MODSET *0PIMSFX*.
-~eor


### PR DESCRIPTION
While testing adding a new mod to the system the new mod did not get included because of an ~eor in the 0PIMSFX.mod file creating a 00 record before the new mod causing the modify run to stop loading any mods after that point.