### PR TITLE
Fix DSD key entry timing for HUSTLER

### DIFF
--- a/HUSTLER/cyber.ini
+++ b/HUSTLER/cyber.ini
@@ -69,7 +69,7 @@ enter_keys #1000#
 enter_keys #1000#1.N
 enter_keys #1000#
 enter_keys #20000#OFF
-enter_keys #45000#D%mon%%day%96
+enter_keys #65000#D%mon%%day%96
 enter_keys #1500#T%hour%%min%%sec%
 enter_keys #1000#3.GO
 enter_keys #1000#ATT.

--- a/HUSTLER/install.js
+++ b/HUSTLER/install.js
@@ -55,7 +55,7 @@ promise = promise
   "#1000#",
   "#2000#GO",
   "#20000#OFF",
-  "#45000#D%mon%%day%96",
+  "#65000#D%mon%%day%96",
   "#1500#T%hour%%min%%sec%",
   "#1000#3.GO",
   "#1000#ATT.",


### PR DESCRIPTION
cyber.ini and install.js don't wait long enough for deadstart to complete before entering the rest of the DSD keys to bring up the system.

I've increased the timeout before entering the date/time to fix this.