### PR TITLE
Errorlog

### DIFF
--- a/DtCyber.vcxproj.user
+++ b/DtCyber.vcxproj.user
@@ -1,15 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <LocalDebuggerWorkingDirectory>..\CybisRelease1.Test</LocalDebuggerWorkingDirectory>
+    <LocalDebuggerWorkingDirectory>E:\Emulation\dtCyber.2025\NOS2.8.7</LocalDebuggerWorkingDirectory>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
-    <LocalDebuggerCommandArguments>
-    </LocalDebuggerCommandArguments>
+    <LocalDebuggerCommandArguments>manual</LocalDebuggerCommandArguments>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <LocalDebuggerWorkingDirectory>..\CybisRelease1.Test</LocalDebuggerWorkingDirectory>
+    <LocalDebuggerWorkingDirectory>E:\Emulation\dtCyber.2025\NOS2.8.7</LocalDebuggerWorkingDirectory>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
-    <LocalDebuggerCommandArguments />
+    <LocalDebuggerCommandArguments>manual</LocalDebuggerCommandArguments>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LocalDebuggerWorkingDirectory>..\CybisRelease1.Test</LocalDebuggerWorkingDirectory>

--- a/cci.h
+++ b/cci.h
@@ -43,10 +43,10 @@
 **  CCI Constants
 **  -------------
 */
-#define BlkOffP     6
-#define BlkOffSP    7
-#define BlkOffLt    8
-#define BlkOffTt    9
+#define BlkOffP                 6
+#define BlkOffSP                7
+#define BlkOffLt                8
+#define BlkOffTt                9
 
 
 #define CciWaitForTcbTimeout    5

--- a/cci_async.c
+++ b/cci_async.c
@@ -187,12 +187,12 @@ void cciAsyncProcessDownlineData(Tcb *tp, NpuBuffer *bp, bool last)
         len--;
         }
 #if DEBUG
-    fprintf(npuAsyncLog,"Send to terminal : ");
-    for(int i = 0; i< len ; i++)
+    fprintf(npuAsyncLog, "Send to terminal : ");
+    for (int i = 0; i < len ; i++)
         {
-        fprintf(npuAsyncLog,"%c", blk[i]);
+        fprintf(npuAsyncLog, "%c", blk[i]);
         }
-    fprintf(npuAsyncLog,"\n");
+    fprintf(npuAsyncLog, "\n");
 #endif
 
     /*
@@ -266,7 +266,7 @@ void cciAsyncProcessUplineNormal(Tcb *tp)
         **  Echo characters.
         */
         *echoPtr++ = ch;
-        echoLen    = echoPtr - echoBuffer;
+        echoLen    = (int)(echoPtr - echoBuffer);
         if (echoLen)
             {
             npuNetSend(tp, echoBuffer, echoLen);
@@ -278,7 +278,7 @@ void cciAsyncProcessUplineNormal(Tcb *tp)
             /*
             **  EOL entered - send the input upline.
             */
-            cciTipSendMsg(tp, tp->inBufPtr - tp->inBuf);
+            cciTipSendMsg(tp, (int)(tp->inBufPtr - tp->inBuf));
 #if DEBUG
             fprintf(npuAsyncLog, "Port %02x: send upline normal data for %.7s, size %ld\n",
                     pcbp->claPort, tp->termName, tp->inBufPtr - tp->inBuf);
@@ -352,7 +352,7 @@ void cciAsyncProcessUplineNormal(Tcb *tp)
             /*
             **  Send long lines.
             */
-            cciTipSendMsg(tp, tp->inBufPtr - tp->inBuf);
+            cciTipSendMsg(tp, (int)(tp->inBufPtr - tp->inBuf));
 #if DEBUG
             fprintf(npuAsyncLog, "Port %02x: send upline long normal data for %.7s, size %ld\n",
                     pcbp->claPort, tp->termName, tp->inBufPtr - tp->inBuf);

--- a/cci_hip.c
+++ b/cci_hip.c
@@ -245,7 +245,7 @@ void cciInit(u8 eqNo, u8 unitNo, u8 channelNo, char *deviceName)
     */
     if (npuSw != SwUndefined)
         {
-        fprintf(stderr, "(cci_hip) CCI and CCP devices are mutually exclusive\n");
+        logDtError(LogErrorLocation, "CCI and CCP devices are mutually exclusive\n");
         exit(1);
         }
     npuSw = SwCCI;
@@ -257,13 +257,13 @@ void cciInit(u8 eqNo, u8 unitNo, u8 channelNo, char *deviceName)
     if (npuSvmCouplerNode != 0)
         {
         npuSvmCouplerNode = 0;
-        fprintf(stderr, "(cci_hip) set coupler node to 0\n");
+        logDtError(LogErrorLocation, "set coupler node to 0\n");
         }
 
     if (npuSvmNpuNode != 2)
         {
         npuSvmNpuNode = 2;
-        fprintf(stderr, "(cci_hip) set npu node to 2\n");
+        logDtError(LogErrorLocation, "set npu node to 2\n");
         }
 
     /*
@@ -284,7 +284,7 @@ void cciInit(u8 eqNo, u8 unitNo, u8 channelNo, char *deviceName)
     cci = calloc(1, sizeof(CciParam));
     if (cci == NULL)
         {
-        fprintf(stderr, "(cci_hip) Failed to allocate cci context block\n");
+        logDtError(LogErrorLocation, "Failed to allocate cci context block\n");
         exit(1);
         }
 
@@ -481,7 +481,7 @@ static void cciReset(void)
     cciHipState = StHipIdle;
 #if (DEBUG > 0)
     fprintf(cciLog, "(cci_hip) NPU reset\n");
-    fprintf(stderr, "(cci_hip) NPU reset\n");
+    logDtError(LogErrorLocation, "NPU reset\n");
 #endif
     }
 
@@ -500,7 +500,7 @@ static FcStatus cciHipFunc(PpWord funcCode)
     CciHcpState oldHcpState;
 
     funcCode &= ~FcNpuEqMask;
-    u16         sum;
+    u16 sum;
 
 #if (DEBUG > 1)
     if (funcCode != FcNpuInCouplerStatus)
@@ -526,7 +526,7 @@ static FcStatus cciHipFunc(PpWord funcCode)
     case FcNpuInCouplerStatus:
 
         switch (cciHipState)
-            {
+        {
         case StHipIdle:
             /*
             **  Poll network status.
@@ -551,7 +551,7 @@ static FcStatus cciHipFunc(PpWord funcCode)
 
         default:
             break;
-            }
+        }
 
         break;
 
@@ -642,14 +642,14 @@ static FcStatus cciHipFunc(PpWord funcCode)
             }
 
         switch (sum)
-            {
+        {
         /*
         ** micro program started, respond with NPU idle state
         */
         case Fp0D0:      // fingerprint of the micro image
 #if (DEBUG > 0)
             fprintf(cciLog, "(cci_hip) NPU start micro program\n");
-            fprintf(stderr, "(cci_hip) NPU start micro program\n");
+            logDtError(LogErrorLocation, "NPU start micro program\n");
 #endif
             cciHipState = StHipIdle;
             oldHcpState = cciHcpState;
@@ -664,7 +664,7 @@ static FcStatus cciHipFunc(PpWord funcCode)
         case Fp0DZ:     // fingerprint of the dump program
 #if (DEBUG > 0)
             fprintf(cciLog, "(cci_hip) NPU start dump program\n");
-            fprintf(stderr, "(cci_hip) NPU start dump program\n");
+            logDtError(LogErrorLocation, "NPU start dump program\n");
 #endif
             cciHipState        = StHipIdle;
             cci->memory[0x1FF] = 1024;
@@ -678,7 +678,7 @@ static FcStatus cciHipFunc(PpWord funcCode)
         case Fp0D1:     // fingerprint of the 0D1 image
 
             switch (cciHcpState)
-                {
+            {
             case StHcpNotInitialized:
 
                 /*
@@ -686,7 +686,7 @@ static FcStatus cciHipFunc(PpWord funcCode)
                 */
 #if (DEBUG > 0)
                 fprintf(cciLog, "(cci_hip) NPU start macro program\n");
-                fprintf(stderr, "(cci_hip) NPU start macro program\n");
+                logDtError(LogErrorLocation, "NPU start macro program\n");
 #endif
                 cciHipState = StHipIdle;
                 cciHcpState = StHcpRunning;
@@ -700,7 +700,7 @@ static FcStatus cciHipFunc(PpWord funcCode)
                 */
 #if (DEBUG > 0)
                 fprintf(cciLog, "(cci_hip) NPU restart macro program\n");
-                fprintf(stderr, "(cci_hip) NPU restart macro program\n");
+                logDtError(LogErrorLocation, "NPU restart macro program\n");
 #endif
                 cciHipState = StHipIdle;
                 cciHcpState = StHcpRunning;
@@ -712,7 +712,7 @@ static FcStatus cciHipFunc(PpWord funcCode)
                 /*
                 ** Error: start NPU while macro program is running
                 */
-                fprintf(stderr, "(cci_hip) Fatal: StartNpu called while macro program is running\n");
+                logDtError(LogErrorLocation, "Fatal: StartNpu called while macro program is running\n");
                 break;
 
             default:
@@ -720,19 +720,19 @@ static FcStatus cciHipFunc(PpWord funcCode)
                 /*
                 ** Error: unknown image loaded
                 */
-                fprintf(stderr, "(cci_hip) Fatal: StartNpu called for unknown image\n");
+                logDtError(LogErrorLocation, "Fatal: StartNpu called for unknown image\n");
                 break;
-                }
-            break;
             }
+            break;
+        }
 
         return (FcProcessed);
-    }      // case funCode
+        }              // case funCode
 
     activeDevice->fcode = funcCode;
 
     return (FcAccepted);
-        }
+    }
 
 /*--------------------------------------------------------------------------
 **  Purpose:        Perform I/O on NPU.
@@ -896,7 +896,7 @@ static void cciHipIo(void)
 #endif
 
             switch (orderCode)
-                {
+            {
             case OrdOutServiceMsg:
                 npuBipNotifyServiceMessage();
                 break;
@@ -912,7 +912,7 @@ static void cciHipIo(void)
             case OrdNotReadyForInput:
                 npuBipRetryInput();
                 break;
-                }
+            }
             }
 
         break;
@@ -937,7 +937,7 @@ static void cciHipIo(void)
     case FcNpuOutMemAddr0:
         if (activeChannel->full)
             {
-            cci->tempMemAddr0   = activeChannel->data;
+            cci->tempMemAddr0   = (u8)activeChannel->data;
             activeChannel->full = FALSE;
             }
         break;

--- a/cci_hip.c
+++ b/cci_hip.c
@@ -526,7 +526,7 @@ static FcStatus cciHipFunc(PpWord funcCode)
     case FcNpuInCouplerStatus:
 
         switch (cciHipState)
-        {
+            {
         case StHipIdle:
             /*
             **  Poll network status.
@@ -551,7 +551,7 @@ static FcStatus cciHipFunc(PpWord funcCode)
 
         default:
             break;
-        }
+            }
 
         break;
 
@@ -642,7 +642,7 @@ static FcStatus cciHipFunc(PpWord funcCode)
             }
 
         switch (sum)
-        {
+            {
         /*
         ** micro program started, respond with NPU idle state
         */
@@ -678,7 +678,7 @@ static FcStatus cciHipFunc(PpWord funcCode)
         case Fp0D1:     // fingerprint of the 0D1 image
 
             switch (cciHcpState)
-            {
+                {
             case StHcpNotInitialized:
 
                 /*
@@ -722,12 +722,12 @@ static FcStatus cciHipFunc(PpWord funcCode)
                 */
                 logDtError(LogErrorLocation, "Fatal: StartNpu called for unknown image\n");
                 break;
-            }
+                }
             break;
-        }
+            }
 
         return (FcProcessed);
-        }              // case funCode
+        }                  // case funCode
 
     activeDevice->fcode = funcCode;
 
@@ -896,7 +896,7 @@ static void cciHipIo(void)
 #endif
 
             switch (orderCode)
-            {
+                {
             case OrdOutServiceMsg:
                 npuBipNotifyServiceMessage();
                 break;
@@ -912,7 +912,7 @@ static void cciHipIo(void)
             case OrdNotReadyForInput:
                 npuBipRetryInput();
                 break;
-            }
+                }
             }
 
         break;

--- a/cci_svm.c
+++ b/cci_svm.c
@@ -370,15 +370,15 @@ void cciSvmSendDiscRequest(Tcb *tp)
 
     case StTermIdle:                   // terminal is not yet configured or connected
     case StTermHostRequestDisconnect:  // disconnection has been requested by host
-        fprintf(stderr, "Warning - disconnect request ignored for %.7s in state %s\n",
-                tp->termName, npuSvmTermStates[tp->state]);
+        logDtError(LogErrorLocation, "Warning - disconnect request ignored for %.7s in state %s\n",
+                   tp->termName, npuSvmTermStates[tp->state]);
 
     case StTermNpuRequestDisconnect:   // disconnection has been requested by NPU/MDI
         break;
 
     default:
-        fprintf(stderr, "(cci_svm) Unrecognized state %d during %.7s disconnect request\n",
-                tp->state, tp->termName);
+        logDtError(LogErrorLocation, "Unrecognized state %d during %.7s disconnect request\n",
+                   tp->state, tp->termName);
         break;
         }
     }
@@ -449,12 +449,12 @@ void cciSvmProcessBuffer(NpuBuffer *bp)
         /*
         **  Service message must be at least DN/SN/0/BSN/PFC/SFC.
         */
-        fprintf(stderr, "(cci_svm) Short message: ");
+        logDtError(LogErrorLocation, "Short message: ");
         for (int i = 0; i < bp->numBytes; i++)
             {
-            fprintf(stderr, " %x", bp->data[i]);
+            logDtError(LogErrorLocation, " %x", bp->data[i]);
             }
-        fprintf(stderr, "\n");
+        logDtError(LogErrorLocation, "\n");
 
         /*
         **  Release downline buffer and return.
@@ -473,8 +473,8 @@ void cciSvmProcessBuffer(NpuBuffer *bp)
         /*
         **  Connection number out of range.
         */
-        fprintf(stderr, "(cci_svm) Connection number is %u but must be zero in SVM messages %02X/%02X\n",
-                cn, block[BlkOffPfc], block[BlkOffSfc]);
+        logDtError(LogErrorLocation, "Connection number is %u but must be zero in SVM messages %02X/%02X\n",
+                   cn, block[BlkOffPfc], block[BlkOffSfc]);
 
         /*
         **  Release downline buffer and return.
@@ -502,8 +502,8 @@ void cciSvmProcessBuffer(NpuBuffer *bp)
             /*
             **  Connection number out of range.
             */
-            fprintf(stderr, "(cci_svm) Port number out of range %02X/%02X\n",
-                    block[BlkOffPfc], block[BlkOffSfc]);
+            logDtError(LogErrorLocation, "Port number out of range %02X/%02X\n",
+                       block[BlkOffPfc], block[BlkOffSfc]);
 
             /*
             **  Release downline buffer and return.
@@ -518,8 +518,8 @@ void cciSvmProcessBuffer(NpuBuffer *bp)
             /*
             **  illegal CLA port number
             */
-            fprintf(stderr, "(cci_svm) illegal CLA port %02X number  %02X/%02X\n",
-                    port, block[BlkOffPfc], block[BlkOffSfc]);
+            logDtError(LogErrorLocation, "Illegal CLA port %02X number  %02X/%02X\n",
+                       port, block[BlkOffPfc], block[BlkOffSfc]);
 
             /*
             **  Release downline buffer and return.
@@ -534,8 +534,8 @@ void cciSvmProcessBuffer(NpuBuffer *bp)
             /*
             **  associated CLA port configured
             */
-            fprintf(stderr, "(cci_svm) CLA port %02X not configured %02X/%02X\n",
-                    port, block[BlkOffPfc], block[BlkOffSfc]);
+            logDtError(LogErrorLocation, "CLA port %02X not configured %02X/%02X\n",
+                       port, block[BlkOffPfc], block[BlkOffSfc]);
 
             /*
             **  Release downline buffer and return.
@@ -556,8 +556,8 @@ void cciSvmProcessBuffer(NpuBuffer *bp)
         /*
         ** No NPU buffer available for response
         */
-        fprintf(stderr, "(cci_svm) No response buffer availabel for SVM messages %02X/%02X\n",
-                block[BlkOffPfc], block[BlkOffSfc]);
+        logDtError(LogErrorLocation, "No response buffer availabel for SVM messages %02X/%02X\n",
+                   block[BlkOffPfc], block[BlkOffSfc]);
 
         /*
         **  Release downline buffer and return.
@@ -603,7 +603,7 @@ void cciSvmProcessBuffer(NpuBuffer *bp)
         if (block[BlkOffLt] != 6)
             {
 #if DEBUG
-            fprintf(stderr, "(cci_svm) port: %u illegal line type %u\n", port, block[BlkOffLt]);
+            logDtError(LogErrorLocation, "Port: %u illegal line type %u\n", port, block[BlkOffLt]);
 #endif
             rc  = rcConfLineInvalidLineType;
             err = TRUE;
@@ -617,7 +617,7 @@ void cciSvmProcessBuffer(NpuBuffer *bp)
  *          if (block[BlkOffTt] != 0x88)
  *              {
  #if DEBUG
- *                  fprintf(stderr,"(cci_svm) port: %u illegal terminal type %u\n",port,block[BlkOffTt]);
+ *                  logDtError(LogErrorLocation, "Port: %u illegal terminal type %u\n",port,block[BlkOffTt]);
  #endif
  *                  rc= rcConfLineInvalidTermType;
  *                  err = TRUE;
@@ -726,8 +726,8 @@ void cciSvmProcessBuffer(NpuBuffer *bp)
             */
                 {
 #if DEBUG
-                fprintf(stderr, "unhandled host line disconnect request P: %d State %d numTerm %d\n",
-                        port, lp->lineState, lp->numTerminals);
+                logDtError(LogErrorLocation, "Unhandled host line disconnect request P: %d State %d numTerm %d\n",
+                           port, lp->lineState, lp->numTerminals);
 #endif
                 rc = cciLnStatInoperative;
                 break;
@@ -856,12 +856,12 @@ void cciSvmProcessBuffer(NpuBuffer *bp)
             break;
             }
 
-        if (tp->state == StTermConnected || tp->state == StTermConnecting)
+        if ((tp->state == StTermConnected) || (tp->state == StTermConnecting))
             {
             /*
             ** Host requests disconnect, output message to terminal
             */
-            send(tp->pcbp->connFd, disconnectMsg, strlen(disconnectMsg), 0);
+            send(tp->pcbp->connFd, disconnectMsg, (int)strlen(disconnectMsg), 0);
             }
 
         if (tp->state == StTermNpuRequestDisconnect)
@@ -1021,7 +1021,7 @@ void cciSvmProcessBuffer(NpuBuffer *bp)
     /*
     ** send response and relase buffer
     */
-    respBuf->numBytes = rp - rpHead;
+    respBuf->numBytes = (u16)(rp - rpHead);
     npuBipRequestUplineTransfer(respBuf);
 
     npuBipBufRelease(bp);
@@ -1345,7 +1345,7 @@ static Tcb *cciSvmFindOwningConsole(Tcb *tp)
             }
         }
 #if DEBUG
-    fprintf(stderr, "(cci_svm) No owning console found for connection %u (%.7s)", tp->cn, tp->termName);
+    logDtError(LogErrorLocation, "No owning console found for connection %u (%.7s)", tp->cn, tp->termName);
 #endif
 
     return NULL; // owning console not found

--- a/cci_tip.c
+++ b/cci_tip.c
@@ -262,7 +262,7 @@ void cciTipProcessBuffer(NpuBuffer *bp, int priority)
     */
     case BtHTCMD:
         switch (block[BlkOffPfc])
-        {
+            {
         case 7:
             /*
             **  Resume output marker after user break 1 or 2.
@@ -285,7 +285,7 @@ void cciTipProcessBuffer(NpuBuffer *bp, int priority)
                 }
 #endif
             break;
-        }
+            }
 
         /*
         **  Acknowledge any command (although most are ignored).
@@ -299,7 +299,7 @@ void cciTipProcessBuffer(NpuBuffer *bp, int priority)
             {
             last = (block[BlkOffBTBSN] & BlkMaskBT) == BtHTMSG;
             switch (tp->tipType)
-            {
+                {
             case TtASYNC:
                 cciAsyncProcessDownlineData(tp, bp, last);
                 break;
@@ -308,7 +308,7 @@ void cciTipProcessBuffer(NpuBuffer *bp, int priority)
             default:
                 logDtError(LogErrorLocation, "(npu_tip) Downline data for unrecognized TIP type %u on connection %u\n",
                            tp->tipType, tp->cn);
-            }
+                }
             cciTipSendAck(tp);
             break;
             }

--- a/cci_tip.c
+++ b/cci_tip.c
@@ -262,7 +262,7 @@ void cciTipProcessBuffer(NpuBuffer *bp, int priority)
     */
     case BtHTCMD:
         switch (block[BlkOffPfc])
-            {
+        {
         case 7:
             /*
             **  Resume output marker after user break 1 or 2.
@@ -279,13 +279,13 @@ void cciTipProcessBuffer(NpuBuffer *bp, int priority)
                         cn, block[BlkOffPfc], block[BlkOffSfc]);
                 for (i = 0; i < bp->numBytes; i++)
                     {
-                    fprintf(stderr, " %02x", bp->data[i]);
+                    logDtError(LogErrorLocation, " %02x", bp->data[i]);
                     }
                 fputs("\n", stderr);
                 }
 #endif
             break;
-            }
+        }
 
         /*
         **  Acknowledge any command (although most are ignored).
@@ -299,16 +299,16 @@ void cciTipProcessBuffer(NpuBuffer *bp, int priority)
             {
             last = (block[BlkOffBTBSN] & BlkMaskBT) == BtHTMSG;
             switch (tp->tipType)
-                {
+            {
             case TtASYNC:
                 cciAsyncProcessDownlineData(tp, bp, last);
                 break;
 
 
             default:
-                fprintf(stderr, "(npu_tip) Downline data for unrecognized TIP type %u on connection %u\n",
-                        tp->tipType, tp->cn);
-                }
+                logDtError(LogErrorLocation, "(npu_tip) Downline data for unrecognized TIP type %u on connection %u\n",
+                           tp->tipType, tp->cn);
+            }
             cciTipSendAck(tp);
             break;
             }

--- a/cdcnet.c
+++ b/cdcnet.c
@@ -637,7 +637,7 @@ void cdcnetProcessDownlineData(NpuBuffer *bp)
         sfc = bp->data[BlkOffSfc];
 
         switch (pfc)
-        {
+            {
         case 0x02:           // initiate connection
             if (sfc == 0x09) // A-A connection
                 {
@@ -723,7 +723,7 @@ void cdcnetProcessDownlineData(NpuBuffer *bp)
 #endif
             npuBipBufRelease(bp);
             break;
-        }
+            }
         break;
 
     case BtHTQBLK:
@@ -941,7 +941,7 @@ void cdcnetCheckStatus(void)
                 blockType = bp->data[BlkOffBTBSN] & BlkMaskBT;
 
                 switch (blockType)
-                {
+                    {
                 case BtHTBLK:
                 case BtHTMSG:
                     bp->offset = BlkOffDbc + 1;
@@ -1010,11 +1010,11 @@ void cdcnetCheckStatus(void)
 #endif
                     npuBipBufRelease(bp);
                     break;
-                }
+                    }
                 }
 
             switch (gp->tcpUdpState)
-            {
+                {
             case StTcpConnecting:
                 FD_SET(gp->connFd, &writeFds);
                 if (gp->connFd > maxFd)
@@ -1052,7 +1052,7 @@ void cdcnetCheckStatus(void)
 
             default: // do nothing
                 break;
-            }
+                }
 
             break;
 

--- a/channel.c
+++ b/channel.c
@@ -103,7 +103,7 @@ void channelInit(u8 count)
     channel      = calloc(MaxChannels, sizeof(ChSlot));
     if (channel == NULL)
         {
-        fprintf(stderr, "(channel) Failed to allocate channel control blocks\n");
+        logDtError(LogErrorLocation, "Failed to allocate channel control blocks\n");
         exit(1);
         }
 
@@ -478,7 +478,7 @@ DevSlot *channelAttach(u8 channelNo, u8 eqNo, u8 devType)
     device = calloc(1, sizeof(DevSlot));
     if (device == NULL)
         {
-        fprintf(stderr, "(channel) Failed to allocate control block for Channel %d\n", channelNo);
+        logDtError(LogErrorLocation, "Failed to allocate control block for Channel %d\n", channelNo);
         exit(1);
         }
 

--- a/console.c
+++ b/console.c
@@ -81,7 +81,7 @@
 **--------------------------------------------------------------------------
 */
 
-#define DEBUG 0
+#define DEBUG    0
 
 /*
 **  -------------
@@ -112,38 +112,38 @@
 /*
 **  CDC 6612 console functions and status codes.
 */
-#define Fc6612Sel64CharLeft      07000
-#define Fc6612Sel32CharLeft      07001
-#define Fc6612Sel16CharLeft      07002
+#define Fc6612Sel64CharLeft        07000
+#define Fc6612Sel32CharLeft        07001
+#define Fc6612Sel16CharLeft        07002
 
-#define Fc6612Sel512DotsLeft     07010
-#define Fc6612Sel512DotsRight    07110
-#define Fc6612SelKeyIn           07020
+#define Fc6612Sel512DotsLeft       07010
+#define Fc6612Sel512DotsRight      07110
+#define Fc6612SelKeyIn             07020
 
-#define Fc6612Sel64CharRight     07100
-#define Fc6612Sel32CharRight     07101
-#define Fc6612Sel16CharRight     07102
+#define Fc6612Sel64CharRight       07100
+#define Fc6612Sel32CharRight       07101
+#define Fc6612Sel16CharRight       07102
 
-#define CycleDataBufSize         16384
-#define CycleDataLimit           (CycleDataBufSize-1)
-#define InBufSize                 1024
-#define OutBufSize               16384
+#define CycleDataBufSize           16384
+#define CycleDataLimit             (CycleDataBufSize - 1)
+#define InBufSize                  1024
+#define OutBufSize                 16384
 
-#define CmdSetXLow                0x80
-#define CmdSetYLow                0x81
-#define CmdSetXHigh               0x82
-#define CmdSetYHigh               0x83
-#define CmdSetScreen              0x84
-#define CmdSetFontType            0x85
-#define CmdEndFrame               0xFF
+#define CmdSetXLow                 0x80
+#define CmdSetYLow                 0x81
+#define CmdSetXHigh                0x82
+#define CmdSetYHigh                0x83
+#define CmdSetScreen               0x84
+#define CmdSetFontType             0x85
+#define CmdEndFrame                0xFF
 
-#define FontTypeDot                  0
-#define FontTypeSmall                1
-#define FontTypeMedium               2
-#define FontTypeLarge                3
+#define FontTypeDot                0
+#define FontTypeSmall              1
+#define FontTypeMedium             2
+#define FontTypeLarge              3
 
-#define InfiniteRefreshInterval      ((u64)1000*60*60*24*365)
-#define MaxCycleDataEntries          5
+#define InfiniteRefreshInterval    ((u64)1000 * 60 * 60 * 24 * 365)
+#define MaxCycleDataEntries        5
 
 /*
 **  -----------------------
@@ -151,14 +151,14 @@
 **  -----------------------
 */
 #if !defined(_WIN32)
-#define INVALID_SOCKET -1
-#define SOCKET int
+#define INVALID_SOCKET    -1
+#define SOCKET            int
 #endif
 
 #if DEBUG
 #define HexColumn(x)      (3 * (x) + 4)
 #define AsciiColumn(x)    (HexColumn(16) + 2 + (x))
-#define LogLineLength     (AsciiColumn(16))
+#define LogLineLength    (AsciiColumn(16))
 #endif
 
 /*
@@ -168,10 +168,10 @@
 */
 typedef struct cycleData
     {
-    int         sum1;           /* Fletcher checksum accumulators */
-    int         sum2;
-    int         first;          /* Index of first accumulated byte in display sequence */
-    int         limit;          /* Index of last + 1 accumulated byte in sequence */
+    int sum1;                   /* Fletcher checksum accumulators */
+    int sum2;
+    int first;                  /* Index of first accumulated byte in display sequence */
+    int limit;                  /* Index of last + 1 accumulated byte in sequence */
     } CycleData;
 
 /*
@@ -196,10 +196,12 @@ static void     consoleQueueChar(u8 ch);
 static void     consoleQueueCmd(u8 cmd, u8 parm);
 static void     consoleQueueCurState(void);
 static void     consoleUpdateChecksum(u16 datum);
+
 #if DEBUG
 static char *consoleCmdToString(u8 cmd);
 static void consoleLogBytes(u8 *bytes, int len);
 static void consoleLogFlush(void);
+
 #endif
 
 /*
@@ -217,7 +219,7 @@ long fontHeightSmall;                 // Console
 long fontLarge;                       // Console
 long fontMedium;                      // Console
 long fontSmall;                       // Console
-char fontName[MaxFontNameSize+1];     // Console
+char fontName[MaxFontNameSize + 1];   // Console
 long heightPX;                        // Console
 long scaleX;                          // Console
 long scaleY;                          // Console
@@ -323,9 +325,9 @@ void consoleInit(u8 eqNo, u8 unitNo, u8 channelNo, char *params)
             fputs("(console) TCP port missing from CO6612 definition\n", stderr);
             exit(1);
             }
-        if (consolePort < 1 || consolePort > 65535)
+        if ((consolePort < 1) || (consolePort > 65535))
             {
-            fprintf(stderr, "(console) Invalid TCP port number in CO6612 definition: %d\n", consolePort);
+            logDtError(LogErrorLocation, "Invalid TCP port number in CO6612 definition: %d\n", consolePort);
             exit(1);
             }
         if (n > 1)
@@ -336,14 +338,14 @@ void consoleInit(u8 eqNo, u8 unitNo, u8 channelNo, char *params)
                 }
             else if (strcasecmp(str, "win") != 0)
                 {
-                fprintf(stderr, "(console) Unrecognized parameter in CO6612 definition: %s\n", str);
+                logDtError(LogErrorLocation, "Unrecognized parameter in CO6612 definition: %s\n", str);
                 exit(1);
                 }
             }
         listenFd = netCreateListener(consolePort);
         if (listenFd == INVALID_SOCKET)
             {
-            fprintf(stderr, "(console) Failed to listen for TCP connections on port %d\n", consolePort);
+            logDtError(LogErrorLocation, "Failed to listen for TCP connections on port %d\n", consolePort);
             exit(1);
             }
         fprintf(stdout, "(console) Listening for connections on port %d\n", consolePort);
@@ -443,19 +445,19 @@ bool consoleIsRemoteActive(void)
 **------------------------------------------------------------------------*/
 void consoleShowStatus(void)
     {
-    char      outBuf[200];
+    char outBuf[200];
 
     if (listenFd != INVALID_SOCKET)
         {
-        sprintf(outBuf, "    >   %-8s C%02o E%02o     ",  "6612", consoleChannelNo, consoleEqNo);
+        sprintf(outBuf, "    >   %-8s C%02o E%02o     ", "6612", consoleChannelNo, consoleEqNo);
         opDisplay(outBuf);
-        sprintf(outBuf, FMTNETSTATUS"\n", netGetLocalTcpAddress(listenFd), "", "console", "listening");
+        sprintf(outBuf, FMTNETSTATUS "\n", netGetLocalTcpAddress(listenFd), "", "console", "listening");
         opDisplay(outBuf);
         if (connFd != INVALID_SOCKET)
             {
-            sprintf(outBuf, "    >   %-8s             ",  "6612");
+            sprintf(outBuf, "    >   %-8s             ", "6612");
             opDisplay(outBuf);
-            sprintf(outBuf, FMTNETSTATUS"\n", netGetLocalTcpAddress(connFd), netGetPeerTcpAddress(connFd), "console", "connected");
+            sprintf(outBuf, FMTNETSTATUS "\n", netGetLocalTcpAddress(connFd), netGetPeerTcpAddress(connFd), "console", "connected");
             opDisplay(outBuf);
             }
         }
@@ -480,7 +482,7 @@ void consoleShowStatus(void)
 **------------------------------------------------------------------------*/
 static FcStatus consoleFunc(PpWord funcCode)
     {
-    if (listenFd != INVALID_SOCKET && connFd == INVALID_SOCKET)
+    if ((listenFd != INVALID_SOCKET) && (connFd == INVALID_SOCKET))
         {
         consoleAcceptConnection();
         }
@@ -644,7 +646,10 @@ static void consoleIo(void)
         break;
         }
 
-    if (connFd != INVALID_SOCKET) consoleNetIo();
+    if (connFd != INVALID_SOCKET)
+        {
+        consoleNetIo();
+        }
     }
 
 /*--------------------------------------------------------------------------
@@ -699,9 +704,12 @@ static void consoleActivate(void)
 static void consoleCheckDisplayCycle(void)
     {
     CycleData *cdp;
-    int i;
+    int       i;
 
-    if (connFd == INVALID_SOCKET) return;
+    if (connFd == INVALID_SOCKET)
+        {
+        return;
+        }
 
     //
     // Search backward for a matching checksum. A cycle is detected if a
@@ -710,28 +718,31 @@ static void consoleCheckDisplayCycle(void)
     for (i = currentCycleDataIndex - 1; i >= 0; i--)
         {
         cdp = &cycleDataSequences[i];
-        if (cdp->sum1 == currentCycleData->sum1 && cdp->sum2 == currentCycleData->sum2)
+        if ((cdp->sum1 == currentCycleData->sum1) && (cdp->sum2 == currentCycleData->sum2))
             {
 #if DEBUG
-            if (queueCharLast) fputs("\n", consoleLog);
+            if (queueCharLast)
+                {
+                fputs("\n", consoleLog);
+                }
             fputs("cycle detected\n", consoleLog);
             queueCharLast = FALSE;
 #endif
             cycleDataBuf[cycleDataIn++] = CmdEndFrame;
-            currentCycleData->limit = cycleDataIn;
+            currentCycleData->limit     = cycleDataIn;
             consoleFlushCycleData(cdp->limit, currentCycleData->limit);
             currentCycleDataIndex = -1;
             break;
             }
         }
     if (currentCycleDataIndex + 1 < MaxCycleDataEntries)
-       {
-       currentCycleDataIndex += 1;
-       currentCycleData = &cycleDataSequences[currentCycleDataIndex];
-       memset(currentCycleData, 0, sizeof(CycleData));
-       currentCycleData->first = currentCycleData->limit = cycleDataIn;
-       consoleQueueCurState();
-       }
+        {
+        currentCycleDataIndex += 1;
+        currentCycleData       = &cycleDataSequences[currentCycleDataIndex];
+        memset(currentCycleData, 0, sizeof(CycleData));
+        currentCycleData->first = currentCycleData->limit = cycleDataIn;
+        consoleQueueCurState();
+        }
     }
 
 /*--------------------------------------------------------------------------
@@ -766,16 +777,19 @@ static void consoleFlushCycleData(int first, int limit)
 
     if (connFd != INVALID_SOCKET)
         {
-        currentTime = getMilliseconds();;
+        currentTime = getMilliseconds();
 #if DEBUG
-        if (queueCharLast) fputs("\n", consoleLog);
+        if (queueCharLast)
+            {
+            fputs("\n", consoleLog);
+            }
         fprintf(consoleLog, "flush: first %d, limit %d, outBufIn %d, currentTime %lu, earliestCycleFlush %lu\n",
-            first, limit, outBufIn, currentTime, earliestCycleFlush);
+                first, limit, outBufIn, currentTime, earliestCycleFlush);
         queueCharLast = FALSE;
 #endif
         if (outBufIn > 0)
             {
-            if (limit > first && currentTime >= earliestCycleFlush)
+            if ((limit > first) && (currentTime >= earliestCycleFlush))
                 {
                 n = limit - first;
                 if (outBufIn + n <= OutBufSize)
@@ -810,9 +824,12 @@ static void consoleFlushCycleData(int first, int limit)
             if (currentTime >= earliestCycleFlush)
                 {
                 len = limit - first;
-                n = send(connFd, &cycleDataBuf[first], len, 0);
+                n   = send(connFd, &cycleDataBuf[first], len, 0);
 #if DEBUG
-                if (n > 0) consoleLogBytes(&cycleDataBuf[first], n);
+                if (n > 0)
+                    {
+                    consoleLogBytes(&cycleDataBuf[first], n);
+                    }
 #endif
                 if (n < len)
                     {
@@ -868,7 +885,7 @@ static void consoleNetIo(void)
     timeout.tv_usec = 0;
     n = select((int)(connFd + 1), &readFds, NULL, NULL, &timeout);
 
-    if (ppKeyIn == 0 && inBufOut < inBufIn)
+    if ((ppKeyIn == 0) && (inBufOut < inBufIn))
         {
         ch = inBuf[inBufOut++];
         if (ch == 0x80) // set minimum refresh interval
@@ -876,24 +893,32 @@ static void consoleNetIo(void)
             if (inBufOut < inBufIn)
                 {
                 minRefreshInterval = inBuf[inBufOut++] * 10;
-                if (minRefreshInterval == 0) minRefreshInterval = InfiniteRefreshInterval;
+                if (minRefreshInterval == 0)
+                    {
+                    minRefreshInterval = InfiniteRefreshInterval;
+                    }
                 earliestCycleFlush = getMilliseconds() + minRefreshInterval;
                 }
             else
                 {
                 inBufOut -= 1;
                 }
+
             return;
             }
         else if (ch == 0x81)
             {
             earliestCycleFlush = 0;
+
             return;
             }
         ppKeyIn = ch;
-        if (inBufOut >= inBufIn) inBufIn = inBufOut = 0;
+        if (inBufOut >= inBufIn)
+            {
+            inBufIn = inBufOut = 0;
+            }
         }
-    if (n > 0 && inBufIn < InBufSize && FD_ISSET(connFd, &readFds))
+    if ((n > 0) && (inBufIn < InBufSize) && FD_ISSET(connFd, &readFds))
         {
         n = recv(connFd, &inBuf[inBufIn], InBufSize - inBufIn, 0);
         if (n <= 0)
@@ -924,7 +949,10 @@ static void consoleQueueChar(u8 ch)
     {
     if (connFd == INVALID_SOCKET)
         {
-        if (isConsoleWindowOpen) windowQueue(ch);
+        if (isConsoleWindowOpen)
+            {
+            windowQueue(ch);
+            }
         }
     else
         {
@@ -936,7 +964,7 @@ static void consoleQueueChar(u8 ch)
         if (currentCycleData->limit > 0)
             {
             cycleDataBuf[cycleDataIn++] = ch;
-            currentCycleData->limit = cycleDataIn;
+            currentCycleData->limit     = cycleDataIn;
             }
 #if DEBUG
         fprintf(consoleLog, "%02x ", ch);
@@ -967,9 +995,12 @@ static void consoleQueueCmd(u8 cmd, u8 parm)
             }
         cycleDataBuf[cycleDataIn++] = cmd;
         cycleDataBuf[cycleDataIn++] = parm;
-        currentCycleData->limit = cycleDataIn;
+        currentCycleData->limit     = cycleDataIn;
 #if DEBUG
-        if (queueCharLast) fputs("\n", consoleLog);
+        if (queueCharLast)
+            {
+            fputs("\n", consoleLog);
+            }
         fprintf(consoleLog, "queueCmd: %s %02x\n", consoleCmdToString(cmd), parm);
         queueCharLast = FALSE;
 #endif
@@ -1021,7 +1052,10 @@ static void consoleSetFontType(u8 fontType)
     {
     if (connFd == INVALID_SOCKET)
         {
-        if (isConsoleWindowOpen) windowSetFont(fontSizes[fontType]);
+        if (isConsoleWindowOpen)
+            {
+            windowSetFont(fontSizes[fontType]);
+            }
         }
     else if (currentFontType != fontType)
         {
@@ -1029,20 +1063,24 @@ static void consoleSetFontType(u8 fontType)
         }
     switch (fontType)
         {
-        case FontTypeDot:
-            currentIncrement = 1;
-            break;
-        case FontTypeSmall:
-            currentIncrement = 8;
-            break;
-        case FontTypeMedium:
-            currentIncrement = 16;
-            break;
-        case FontTypeLarge:
-            currentIncrement = 32;
-            break;
-        default:
-            break;
+    case FontTypeDot:
+        currentIncrement = 1;
+        break;
+
+    case FontTypeSmall:
+        currentIncrement = 8;
+        break;
+
+    case FontTypeMedium:
+        currentIncrement = 16;
+        break;
+
+    case FontTypeLarge:
+        currentIncrement = 32;
+        break;
+
+    default:
+        break;
         }
     currentFontType = fontType;
     }
@@ -1080,7 +1118,10 @@ static void consoleSetX(u16 x)
     consoleUpdateChecksum(x);
     if (connFd == INVALID_SOCKET)
         {
-        if (isConsoleWindowOpen) windowSetX(x + xOffsets[currentScreen]);
+        if (isConsoleWindowOpen)
+            {
+            windowSetX(x + xOffsets[currentScreen]);
+            }
         }
     else if (x > 0xff)
         {
@@ -1107,7 +1148,10 @@ static void consoleSetY(u16 y)
     consoleUpdateChecksum(y);
     if (connFd == INVALID_SOCKET)
         {
-        if (isConsoleWindowOpen) windowSetY(y);
+        if (isConsoleWindowOpen)
+            {
+            windowSetY(y);
+            }
         }
     else if (y > 0xff)
         {
@@ -1142,15 +1186,30 @@ static char *consoleCmdToString(u8 cmd)
 
     switch (cmd)
         {
-    case CmdSetXLow:     return "setXLow";
-    case CmdSetYLow:     return "setYLow";
-    case CmdSetXHigh:    return "setXHigh";
-    case CmdSetYHigh:    return "setYHigh";
-    case CmdSetScreen:   return "setScreen";
-    case CmdSetFontType: return "setFontType";
-    case CmdEndFrame:    return "endFrame";
+    case CmdSetXLow:
+        return "setXLow";
+
+    case CmdSetYLow:
+        return "setYLow";
+
+    case CmdSetXHigh:
+        return "setXHigh";
+
+    case CmdSetYHigh:
+        return "setYHigh";
+
+    case CmdSetScreen:
+        return "setScreen";
+
+    case CmdSetFontType:
+        return "setFontType";
+
+    case CmdEndFrame:
+        return "endFrame";
+
     default:
         sprintf(buf, "%02x", cmd);
+
         return buf;
         }
     }

--- a/const.h
+++ b/const.h
@@ -42,7 +42,7 @@
     Portions Copyright:\n \
         (c) 2018-2025 Kevin Jordan\n \
         (c) 2011-2022 Paul Koning\n \
-        (c) 2017-2022 Steven Zoppi\n \
+        (c) 2017-2025 Steven Zoppi\n \
         (c) 2006-2022 Mark Rustad\n \
         (c) 2005      Mark Riordan"
 #define DtCyberLicense      "Licensed under the terms of the GNU General Public License version 3"
@@ -148,9 +148,9 @@
 #define FontDot                    0
 
 #if defined(_WIN32)
-#define MaxFontNameSize LF_FACESIZE
+#define MaxFontNameSize            LF_FACESIZE
 #else
-#define MaxFontNameSize 64
+#define MaxFontNameSize            64
 #endif
 
 
@@ -272,18 +272,18 @@
 #define stricmp                    strcasecmp
 #endif
 #if defined(_WIN32)
-#define fdopen                     _fdopen
-#define fileno                     _fileno
-#define getcwd                     _getcwd
-#define strcasecmp                 _stricmp
-#define stricmp                    _stricmp
-#define tolower                    _tolower
-#define strncasecmp                _strnicmp
-#define unlink                     _unlink
-#define realpath(N, R)             _fullpath((R), (N), sizeof(R))
-#define fprintf(S, F, ...)         fprintf_s(S, F, __VA_ARGS__)
-#define sprintf(S, F, ...)         sprintf_s(S, sizeof(S), F, __VA_ARGS__)
-#define vfprintf(S, F, ...)        vfprintf_s(S, F, __VA_ARGS__)
+#define fdopen         _fdopen
+#define fileno         _fileno
+#define getcwd         _getcwd
+#define strcasecmp     _stricmp
+#define stricmp        _stricmp
+#define tolower        _tolower
+#define strncasecmp    _strnicmp
+#define unlink         _unlink
+#define realpath(N, R)         _fullpath((R), (N), sizeof(R))
+#define fprintf(S, F, ...)     fprintf_s(S, F, __VA_ARGS__)
+#define sprintf(S, F, ...)     sprintf_s(S, sizeof(S), F, __VA_ARGS__)
+#define vfprintf(S, F, ...)    vfprintf_s(S, F, __VA_ARGS__)
 
 #if !defined(MSG_WAITALL)
 #define MSG_WAITALL    0x8

--- a/cp3446.c
+++ b/cp3446.c
@@ -221,14 +221,14 @@ void cp3446Init(u8 eqNo, u8 unitNo, u8 channelNo, char *deviceName)
     */
     if (up->context[0] != NULL)
         {
-        fprintf(stderr, "(cp3446 ) Only one CP3446 unit is possible per equipment\n");
+        logDtError(LogErrorLocation, "Only one CP3446 unit is possible per equipment\n");
         exit(1);
         }
 
     cc = calloc(1, sizeof(CpContext));
     if (cc == NULL)
         {
-        fprintf(stderr, "(cp3446 ) Failed to allocate CP3446 context block\n");
+        logDtError(LogErrorLocation, "Failed to allocate CP3446 context block\n");
         exit(1);
         }
 
@@ -263,7 +263,7 @@ void cp3446Init(u8 eqNo, u8 unitNo, u8 channelNo, char *deviceName)
     up->fcb[0] = fopen(cc->curFileName, "w");
     if (up->fcb[0] == NULL)
         {
-        fprintf(stderr, "(cp3446 ) Failed to open %s\n", cc->curFileName);
+        logDtError(LogErrorLocation, "Failed to open %s\n", cc->curFileName);
         exit(1);
         }
 
@@ -279,7 +279,7 @@ void cp3446Init(u8 eqNo, u8 unitNo, u8 channelNo, char *deviceName)
             }
         else if (strcmp(deviceType, "026") != 0)
             {
-            fprintf(stderr, "(cp3446 ) Unrecognized card code name '%s'\n", deviceType);
+            logDtError(LogErrorLocation, "Unrecognized card code name '%s'\n", deviceType);
             exit(1);
             }
         }
@@ -340,7 +340,7 @@ void cp3446RemoveCards(char *params)
     int isuffix;
 
     struct tm   t;
-    char        fnameNew[MaxFSPath+64];
+    char        fnameNew[MaxFSPath + 64];
     static char msgBuf[80] = "";
     char        outBuf[400];
 
@@ -398,8 +398,8 @@ void cp3446RemoveCards(char *params)
         {
         renameOK = TRUE;        //  Since nothing was open - we're not renaming
         sprintf(outBuf, "(cp3446 ) cp3446RemoveCards: FCB is Null on channel %o equipment %o\n",
-               dp->channel->id,
-               dp->eqNo);
+                dp->channel->id,
+                dp->eqNo);
         opDisplay(outBuf);
         //  proceed to attempt to open a new FCB
         }
@@ -466,11 +466,12 @@ void cp3446RemoveCards(char *params)
         {
         sprintf(outBuf, "(cp3446 ) Failed to open %s\n", cc->curFileName);
         opDisplay(outBuf);
+
         return;
         }
 
-        sprintf(outBuf, "(cp3446 ) Cards removed and available on '%s'\n", fnameNew);
-        opDisplay(outBuf);
+    sprintf(outBuf, "(cp3446 ) Cards removed and available on '%s'\n", fnameNew);
+    opDisplay(outBuf);
     }
 
 /*
@@ -921,7 +922,7 @@ static char *cp3446Func2String(PpWord funcCode)
 void cp3446ShowStatus()
     {
     CpContext *cp;
-    char      outBuf[MaxFSPath+128];
+    char      outBuf[MaxFSPath + 128];
 
     for (cp = firstUnit; cp != NULL; cp = cp->nextUnit)
         {
@@ -930,7 +931,10 @@ void cp3446ShowStatus()
         sprintf(outBuf, "   %-20s (", cp->curFileName);
         opDisplay(outBuf);
         opDisplay(cp->binary ? "bin" : "char");
-        if (cp->rawCard) opDisplay(", raw");
+        if (cp->rawCard)
+            {
+            opDisplay(", raw");
+            }
         opDisplay(")\n");
         }
     }

--- a/cr3447.c
+++ b/cr3447.c
@@ -320,7 +320,7 @@ void cr3447Init(u8 eqNo, u8 unitNo, u8 channelNo, char *deviceName)
             }
         else if ((strcasecmp(tokenAuto, "auto") != 0) && (strcasecmp(tokenAuto, "*") != 0))
             {
-            fprintf(stderr, "(cr3447 ) Unrecognized Automation Type '%s'\n", tokenAuto);
+            logDtError(LogErrorLocation, "Unrecognized Automation Type '%s'\n", tokenAuto);
             exit(1);
             }
         }
@@ -341,11 +341,11 @@ void cr3447Init(u8 eqNo, u8 unitNo, u8 channelNo, char *deviceName)
             {
             cc->table = asciiTo029;
             }
-        else if ((strcasecmp(xlateTable, "026")  != 0)
+        else if ((strcasecmp(xlateTable, "026") != 0)
                  && (strcmp(xlateTable, "*") != 0)
-                 && (strcmp(xlateTable, "")  != 0))
+                 && (strcmp(xlateTable, "") != 0))
             {
-            fprintf(stderr, "(cr3447 ) Unrecognized card code name %s\n", xlateTable);
+            logDtError(LogErrorLocation, "Unrecognized card code name %s\n", xlateTable);
             exit(1);
             }
         }
@@ -361,23 +361,23 @@ void cr3447Init(u8 eqNo, u8 unitNo, u8 channelNo, char *deviceName)
 
     if ((crOutput != NULL)
         && (strcmp(crOutput, "*") != 0)
-        && (strcmp(crOutput, "")  != 0))
+        && (strcmp(crOutput, "") != 0))
         {
         if (stat(crOutput, &s) != 0)
             {
-            fprintf(stderr, "(cr3447 ) The output location specified '%s' does not exist.\n", crOutput);
+            logDtError(LogErrorLocation, "The output location specified '%s' does not exist.\n", crOutput);
             exit(1);
             }
 
         if ((s.st_mode & S_IFDIR) == 0)
             {
-            fprintf(stderr, "(cr3447 ) The output location specified '%s' is not a directory.\n", crOutput);
+            logDtError(LogErrorLocation, "The output location specified '%s' is not a directory.\n", crOutput);
             exit(1);
             }
-        len = strlen(crOutput);
+        len = (int)strlen(crOutput);
         threadParms->outDoneDir = (char *)calloc(len + 1, 1);
         cc->dirOutput           = (char *)calloc(len + 1, 1);
-        if (threadParms->outDoneDir == NULL || cc->dirOutput == NULL)
+        if ((threadParms->outDoneDir == NULL) || (cc->dirOutput == NULL))
             {
             fputs("(cr3447 ) Failed to allocate storage for output directory path\n", stderr);
             exit(1);
@@ -393,17 +393,17 @@ void cr3447Init(u8 eqNo, u8 unitNo, u8 channelNo, char *deviceName)
 
     if ((crInput != NULL)
         && (strcmp(crInput, "*") != 0)
-        && (strcmp(crInput, "")  != 0))
+        && (strcmp(crInput, "") != 0))
         {
         if (stat(crInput, &s) != 0)
             {
-            fprintf(stderr, "(cr3447 ) The Input location specified '%s' does not exist.\n", crInput);
+            logDtError(LogErrorLocation, "The Input location specified '%s' does not exist.\n", crInput);
             exit(1);
             }
 
         if ((s.st_mode & S_IFDIR) == 0)
             {
-            fprintf(stderr, "(cr3447 ) The Input location specified '%s' is not a directory.\n", crInput);
+            logDtError(LogErrorLocation, "The Input location specified '%s' is not a directory.\n", crInput);
             exit(1);
             }
         //  We only care about the "Auto" "NoAuto" flag if there is a good input location
@@ -414,10 +414,10 @@ void cr3447Init(u8 eqNo, u8 unitNo, u8 channelNo, char *deviceName)
         **  The Card Reader Context needs to remember what directory
         **  will supply the input files so more can be found at EOD.
         */
-        len = strlen(crInput);
+        len = (int)strlen(crInput);
         threadParms->inWatchDir = (char *)calloc(len + 1, 1);
         cc->dirInput            = (char *)calloc(len + 1, 1);
-        if (threadParms->inWatchDir == NULL || cc->dirInput == NULL)
+        if ((threadParms->inWatchDir == NULL) || (cc->dirInput == NULL))
             {
             fputs("(cr3447 ) Failed to allocate storage for input directory path\n", stderr);
             exit(1);
@@ -429,7 +429,7 @@ void cr3447Init(u8 eqNo, u8 unitNo, u8 channelNo, char *deviceName)
         threadParms->unitNo    = unitNo;
         threadParms->channelNo = channelNo;
         // threadParms->LoadCards = cr3447LoadCards;
-        threadParms->devType   = DtCr3447;
+        threadParms->devType = DtCr3447;
 
         /*
         **  At this point, we should have a completed context
@@ -511,7 +511,7 @@ void cr3447LoadCards(char *fname, int channelNo, int equipmentNo, char *params)
     CrContext   *cc;
     DevSlot     *dp;
     int         len;
-    char        outBuf[MaxFSPath+128];
+    char        outBuf[MaxFSPath + 128];
     struct stat s;
     char        *sp;
 
@@ -543,12 +543,13 @@ void cr3447LoadCards(char *fname, int channelNo, int equipmentNo, char *params)
         {
         sprintf(outBuf, "(cr3447 ) Requested file '%s' not found. (%s).\n", fname, strerror(errno));
         opDisplay(outBuf);
+
         return;
         }
 
     //  Enqueue the file in the chain of pending files
 
-    len = strlen(fname);
+    len = (int)strlen(fname);
     sp  = (char *)calloc(len + 1, 1);
     memcpy(sp, fname, len);
     cc->decks[cc->inDeck] = sp;
@@ -589,11 +590,11 @@ void cr3447GetNextDeck(char *fname, int channelNo, int equipmentNo, char *params
     DIR           *curDir;
     struct dirent *curDirEntry;
     DevSlot       *dp;
-    char          fOldest[MaxFSPath*2+2] = "";
-    char          outBuf[MaxFSPath*2+64];
+    char          fOldest[MaxFSPath * 2 + 2] = "";
+    char          outBuf[MaxFSPath * 2 + 64];
     struct stat   s;
-    char          strWork[MaxFSPath*2+2] = "";
-    time_t        tOldest            = 0;
+    char          strWork[MaxFSPath * 2 + 2] = "";
+    time_t        tOldest = 0;
 
     /*
     **  Safety check, we only respond if the first
@@ -603,6 +604,7 @@ void cr3447GetNextDeck(char *fname, int channelNo, int equipmentNo, char *params
         {
         sprintf(outBuf, "(cr3447 ) cr3447GetNextDeck called with improper parameter '%s'.\n", fname);
         opDisplay(outBuf);
+
         return;
         }
 
@@ -671,10 +673,16 @@ void cr3447GetNextDeck(char *fname, int channelNo, int equipmentNo, char *params
     do
         {
         curDirEntry = readdir(curDir);
-        if (curDirEntry == NULL) break;
+        if (curDirEntry == NULL)
+            {
+            break;
+            }
 
         //  Pop over the dot (.) directories
-        if (*curDirEntry->d_name == '.') continue;
+        if (*curDirEntry->d_name == '.')
+            {
+            continue;
+            }
 
         sprintf(strWork, "%s/%s", cc->dirInput, curDirEntry->d_name);
         stat(strWork, &s);
@@ -738,7 +746,7 @@ void cr3447PostProcess(char *fname, int channelNo, int equipmentNo, char *params
     {
     CrContext *cc;
     DevSlot   *dp;
-    char      outBuf[MaxFSPath+64];
+    char      outBuf[MaxFSPath + 64];
 
     /*
     **  Locate the device control block.
@@ -755,13 +763,14 @@ void cr3447PostProcess(char *fname, int channelNo, int equipmentNo, char *params
         {
         sprintf(outBuf, "(cr3447 ) Submitted deck '%s' processing complete.\n", fname);
         opDisplay(outBuf);
+
         return;
         }
 
     //
     // If the file is from the configured input directory, it can be deleted.
     //
-    if (strncmp(fname, cc->dirInput, strlen(cc->dirInput)) == 0) 
+    if (strncmp(fname, cc->dirInput, strlen(cc->dirInput)) == 0)
         {
         sprintf(outBuf, "(cr3447 ) Purging submitted deck '%s'.\n", fname);
         opDisplay(outBuf);
@@ -783,12 +792,12 @@ void cr3447PostProcess(char *fname, int channelNo, int equipmentNo, char *params
 **------------------------------------------------------------------------*/
 static void cr3447SwapInOut(CrContext *cc, char *fName)
     {
-    char fnwork[MaxFSPath*2+32] = "";
-    char outBuf[MaxFSPath+2+64];
-    
+    char fnwork[MaxFSPath * 2 + 32] = "";
+    char outBuf[MaxFSPath + 2 + 64];
+
 
     //  If either directory isn't specified, just ignore the rename.
-    if (cc->dirOutput == NULL || cc->dirInput == NULL)
+    if ((cc->dirOutput == NULL) || (cc->dirInput == NULL))
         {
         return;
         }
@@ -860,7 +869,7 @@ static void cr3447SwapInOut(CrContext *cc, char *fName)
 void cr3447ShowStatus()
     {
     CrContext *cp;
-    char      outBuf[MaxFSPath*2+64];
+    char      outBuf[MaxFSPath * 2 + 64];
 
     for (cp = firstCr3447; cp != NULL; cp = cp->nextUnit)
         {
@@ -869,7 +878,10 @@ void cr3447ShowStatus()
         sprintf(outBuf, "   %-20s (", cp->curFileName != NULL ? cp->curFileName : "");
         opDisplay(outBuf);
         opDisplay(cp->binary ? "bin" : "char");
-        if (cp->rawCard) opDisplay(", raw");
+        if (cp->rawCard)
+            {
+            opDisplay(", raw");
+            }
         sprintf(outBuf, ", seq %d", cp->seqNum);
         if (cp->isWatched)
             {
@@ -1171,7 +1183,7 @@ static void cr3447Disconnect(void)
 static bool cr3447StartNextDeck(DevSlot *up, CrContext *cc)
     {
     char *fname;
-    char outBuf[MaxFSPath+128];
+    char outBuf[MaxFSPath + 128];
 
     while (cc->outDeck != cc->inDeck)
         {
@@ -1179,14 +1191,15 @@ static bool cr3447StartNextDeck(DevSlot *up, CrContext *cc)
         up->fcb[0] = fopen(fname, "r");
         if (up->fcb[0] != NULL)
             {
-            cc->status = StCr3447Eof;
-            cc->status = StCr3447Ready;
+            cc->status      = StCr3447Eof;
+            cc->status      = StCr3447Ready;
             cc->curFileName = fname;
             cr3447NextCard(up, cc);
             activeDevice = channelFindDevice(up->channel->id, DtDcc6681);
             dcc6681Interrupt((cc->status & cc->intMask) != 0);
             sprintf(outBuf, "\n(cr3447 ) Cards '%s' loaded on card reader C%02o,E%02o\n", cc->curFileName, cc->channelNo, cc->eqNo);
             opDisplay(outBuf);
+
             return TRUE;
             }
         sprintf(outBuf, "(cr3447 ) Failed to open card deck '%s'\n", fname);
@@ -1196,7 +1209,7 @@ static bool cr3447StartNextDeck(DevSlot *up, CrContext *cc)
         cc->outDeck = (cc->outDeck + 1) % Cr3447MaxDecks;
         }
     cc->curFileName = NULL;
-    up->fcb[0] = NULL;
+    up->fcb[0]      = NULL;
 
     return FALSE;
     }
@@ -1217,7 +1230,7 @@ static void cr3447NextCard(DevSlot *up, CrContext *cc)
     char        *cp;
     int         i;
     int         j;
-    char        outBuf[MaxFSPath+128];
+    char        outBuf[MaxFSPath + 128];
     int         value;
 
     /*

--- a/cr405.c
+++ b/cr405.c
@@ -257,13 +257,13 @@ void cr405Init(u8 eqNo, u8 unitNo, u8 channelNo, char *deviceName)
 
     if (eqNo != 0)
         {
-        fprintf(stderr, "(cr405  ) Invalid equipment number - hardwired to equipment number 0\n");
+        logDtError(LogErrorLocation, "Invalid equipment number - hardwired to equipment number 0\n");
         exit(1);
         }
 
     if (unitNo != 0)
         {
-        fprintf(stderr, "(cr405  ) Invalid unit number - hardwired to unit number 0\n");
+        logDtError(LogErrorLocation, "Invalid unit number - hardwired to unit number 0\n");
         exit(1);
         }
 
@@ -280,14 +280,14 @@ void cr405Init(u8 eqNo, u8 unitNo, u8 channelNo, char *deviceName)
     */
     if (dp->context[0] != NULL)
         {
-        fprintf(stderr, "(cr405  ) Only one unit is possible per equipment\n");
+        logDtError(LogErrorLocation, "Only one unit is possible per equipment\n");
         exit(1);
         }
 
     cc = calloc(1, sizeof(Cr405Context));
     if (cc == NULL)
         {
-        fprintf(stderr, "(cr405  ) Failed to allocate context block\n");
+        logDtError(LogErrorLocation, "Failed to allocate context block\n");
         exit(1);
         }
 
@@ -296,7 +296,7 @@ void cr405Init(u8 eqNo, u8 unitNo, u8 channelNo, char *deviceName)
     threadParms = calloc(1, sizeof(fswContext));    //  Need to check for null result
     if (cc == NULL)
         {
-        fprintf(stderr, "(cr405  ) Failed to allocate CR3447 FileWatcher Context block\n");
+        logDtError(LogErrorLocation, "Failed to allocate CR3447 FileWatcher Context block\n");
         exit(1);
         }
 
@@ -322,7 +322,7 @@ void cr405Init(u8 eqNo, u8 unitNo, u8 channelNo, char *deviceName)
             }
         else if ((strcasecmp(tokenAuto, "auto") != 0) && (strcasecmp(tokenAuto, "*") != 0))
             {
-            fprintf(stderr, "(cr405  ) Unrecognized Automation Type '%s'\n", tokenAuto);
+            logDtError(LogErrorLocation, "Unrecognized Automation Type '%s'\n", tokenAuto);
             exit(1);
             }
         }
@@ -352,7 +352,7 @@ void cr405Init(u8 eqNo, u8 unitNo, u8 channelNo, char *deviceName)
                  && (strcmp(xlateTable, "*") != 0)
                  && (strcmp(xlateTable, "") != 0))
             {
-            fprintf(stderr, "(cr405  ) Unrecognized card code name %s\n", xlateTable);
+            logDtError(LogErrorLocation, "Unrecognized card code name %s\n", xlateTable);
             exit(1);
             }
         }
@@ -370,19 +370,19 @@ void cr405Init(u8 eqNo, u8 unitNo, u8 channelNo, char *deviceName)
         {
         if (stat(crOutput, &s) != 0)
             {
-            fprintf(stderr, "(cr405  ) The Output location specified '%s' does not exist.\n", crOutput);
+            logDtError(LogErrorLocation, "The Output location specified '%s' does not exist.\n", crOutput);
             exit(1);
             }
 
         if ((s.st_mode & S_IFDIR) == 0)
             {
-            fprintf(stderr, "(cr405  ) The Output location specified '%s' is not a directory.\n", crOutput);
+            logDtError(LogErrorLocation, "The Output location specified '%s' is not a directory.\n", crOutput);
             exit(1);
             }
-        len = strlen(crOutput);
+        len = (int)strlen(crOutput);
         threadParms->outDoneDir = (char *)calloc(len + 1, 1);
         cc->dirOutput           = (char *)calloc(len + 1, 1);
-        if (threadParms->outDoneDir == NULL || cc->dirOutput == NULL)
+        if ((threadParms->outDoneDir == NULL) || (cc->dirOutput == NULL))
             {
             fputs("(cr405  ) Failed to allocate storage for output directory path\n", stderr);
             exit(1);
@@ -400,13 +400,13 @@ void cr405Init(u8 eqNo, u8 unitNo, u8 channelNo, char *deviceName)
         {
         if (stat(crInput, &s) != 0)
             {
-            fprintf(stderr, "(cr405  ) The Input location specified '%s' does not exist.\n", crInput);
+            logDtError(LogErrorLocation, "The Input location specified '%s' does not exist.\n", crInput);
             exit(1);
             }
 
         if ((s.st_mode & S_IFDIR) == 0)
             {
-            fprintf(stderr, "(cr405  ) The Input location specified '%s' is not a directory.\n", crInput);
+            logDtError(LogErrorLocation, "The Input location specified '%s' is not a directory.\n", crInput);
             exit(1);
             }
         //  We only care about the "Auto" "NoAuto" flag if there is a good input location
@@ -417,10 +417,10 @@ void cr405Init(u8 eqNo, u8 unitNo, u8 channelNo, char *deviceName)
         **  The Card Reader Context needs to remember what directory
         **  will supply the input files so more can be found at EOD.
         */
-        len = strlen(crInput);
+        len = (int)strlen(crInput);
         threadParms->inWatchDir = (char *)calloc(len + 1, 1);
         cc->dirInput            = (char *)calloc(len + 1, 1);
-        if (threadParms->inWatchDir == NULL || cc->dirInput == NULL)
+        if ((threadParms->inWatchDir == NULL) || (cc->dirInput == NULL))
             {
             fputs("(cr405  ) Failed to allocate storage for input directory path\n", stderr);
             exit(1);
@@ -515,7 +515,7 @@ void cr405LoadCards(char *fname, int channelNo, int equipmentNo, char *params)
     Cr405Context *cc;
     DevSlot      *dp;
     int          len;
-    char         outBuf[MaxFSPath+128];
+    char         outBuf[MaxFSPath + 128];
     struct stat  s;
     char         *sp;
 
@@ -547,12 +547,13 @@ void cr405LoadCards(char *fname, int channelNo, int equipmentNo, char *params)
         {
         sprintf(outBuf, "(cr405  ) Requested file '%s' not found. (%s).\n", fname, strerror(errno));
         opDisplay(outBuf);
+
         return;
         }
 
     //  Enqueue the file in the chain of pending files
 
-    len = strlen(fname) + 1;
+    len = (int)strlen(fname) + 1;
     sp  = (char *)malloc(len);
     memcpy(sp, fname, len);
     cc->decks[cc->inDeck] = sp;
@@ -592,11 +593,11 @@ void cr405GetNextDeck(char *fname, int channelNo, int equipmentNo, char *params)
     DIR           *curDir;
     struct dirent *curDirEntry;
     DevSlot       *dp;
-    char          fOldest[MaxFSPath*2+2] = "";
-    char          outBuf[MaxFSPath*2+128];
+    char          fOldest[MaxFSPath * 2 + 2] = "";
+    char          outBuf[MaxFSPath * 2 + 128];
     struct stat   s;
-    char          strWork[MaxFSPath*2+2] = "";
-    time_t        tOldest            = 0;
+    char          strWork[MaxFSPath * 2 + 2] = "";
+    time_t        tOldest = 0;
 
     //  Safety check, we only respond if the first
     //  character of the filename is an asterisk '*'
@@ -605,6 +606,7 @@ void cr405GetNextDeck(char *fname, int channelNo, int equipmentNo, char *params)
         {
         sprintf(outBuf, "(cr405  ) GetNextDeck called with improper parameter '%s'.\n", fname);
         opDisplay(outBuf);
+
         return;
         }
 
@@ -666,10 +668,16 @@ void cr405GetNextDeck(char *fname, int channelNo, int equipmentNo, char *params)
     do
         {
         curDirEntry = readdir(curDir);
-        if (curDirEntry == NULL) break;
+        if (curDirEntry == NULL)
+            {
+            break;
+            }
 
         //  Pop over the dot (.) directories
-        if (curDirEntry->d_name[0] == '.') continue;
+        if (curDirEntry->d_name[0] == '.')
+            {
+            continue;
+            }
 
         sprintf(strWork, "%s/%s", cc->dirInput, curDirEntry->d_name);
         stat(strWork, &s);
@@ -733,7 +741,7 @@ void cr405PostProcess(char *fname, int channelNo, int equipmentNo, char *params)
     {
     Cr405Context *cc;
     DevSlot      *dp;
-    char         outBuf[MaxFSPath*2+128];
+    char         outBuf[MaxFSPath * 2 + 128];
 
     /*
     **  Locate the device control block.
@@ -751,6 +759,7 @@ void cr405PostProcess(char *fname, int channelNo, int equipmentNo, char *params)
         {
         sprintf(outBuf, "(cr405  ) Submitted deck '%s' processing complete.\n", fname);
         opDisplay(outBuf);
+
         return;
         }
 
@@ -778,11 +787,11 @@ void cr405PostProcess(char *fname, int channelNo, int equipmentNo, char *params)
 **------------------------------------------------------------------------*/
 static void cr405SwapInOut(Cr405Context *cc, char *fName)
     {
-    char fnwork[MaxFSPath*2+32] = "";
-    char outBuf[MaxFSPath*2+128];
+    char fnwork[MaxFSPath * 2 + 32] = "";
+    char outBuf[MaxFSPath * 2 + 128];
 
     //  If either directory isn't specified, just ignore the rename.
-    if (cc->dirOutput == NULL || cc->dirInput == NULL)
+    if ((cc->dirOutput == NULL) || (cc->dirInput == NULL))
         {
         return;
         }
@@ -854,7 +863,7 @@ static void cr405SwapInOut(Cr405Context *cc, char *fName)
 void cr405ShowStatus()
     {
     Cr405Context *cp;
-    char         outBuf[MaxFSPath*2+64];
+    char         outBuf[MaxFSPath * 2 + 64];
 
     for (cp = firstCr405; cp != NULL; cp = cp->nextUnit)
         {
@@ -1024,7 +1033,7 @@ static void cr405Disconnect(void)
 static bool cr405StartNextDeck(DevSlot *dp, Cr405Context *cc)
     {
     char *fname;
-    char outBuf[MaxFSPath+128];
+    char outBuf[MaxFSPath + 128];
 
     while (cc->outDeck != cc->inDeck)
         {
@@ -1036,15 +1045,16 @@ static bool cr405StartNextDeck(DevSlot *dp, Cr405Context *cc)
             cr405NextCard(dp);
             sprintf(outBuf, "Cards '%s' loaded on card reader C%o,E%o\n", cc->curFileName, cc->channelNo, cc->eqNo);
             opDisplay(outBuf);
+
             return TRUE;
             }
-        fprintf(stderr, "Failed to open card deck '%s'\n", fname);
+        logDtError(LogErrorLocation, "Failed to open card deck '%s'\n", fname);
         unlink(fname);
         free(fname);
         cc->outDeck = (cc->outDeck + 1) % Cr405MaxDecks;
         }
     cc->curFileName = NULL;
-    dp->fcb[0] = NULL;
+    dp->fcb[0]      = NULL;
 
     return FALSE;
     }
@@ -1066,7 +1076,7 @@ static void cr405NextCard(DevSlot *dp)
     char         *cp;
     int          i;
     int          j;
-    char         outBuf[MaxFSPath+128];
+    char         outBuf[MaxFSPath + 128];
     int          value;
 
     if (dp->fcb[0] == NULL)

--- a/cray_station.c
+++ b/cray_station.c
@@ -288,8 +288,8 @@ void csFeiInit(u8 eqNo, u8 unitNo, u8 channelNo, char *deviceName)
 
     if (deviceName == NULL)
         {
-        fprintf(stderr, "(crayfei) Cray computer simulator connection information required for FEI on channel %o equipment %o unit %o\n",
-                channelNo, eqNo, unitNo);
+        logDtError(LogErrorLocation, "Cray computer simulator connection information required for FEI on channel %o equipment %o unit %o\n",
+                   channelNo, eqNo, unitNo);
         exit(1);
         }
 
@@ -321,10 +321,10 @@ void csFeiInit(u8 eqNo, u8 unitNo, u8 channelNo, char *deviceName)
     feip = calloc(1, sizeof(FeiParam));
     if (feip == NULL)
         {
-        fprintf(stderr, "(crayfei) Failed to allocate Cray Station FEI context block\n");
+        logDtError(LogErrorLocation, "Failed to allocate Cray Station FEI context block\n");
         exit(1);
         }
-    dp->controllerContext       = feip;
+    dp->controllerContext = feip;
     if (firstFei == NULL)
         {
         firstFei = feip;
@@ -369,7 +369,7 @@ void csFeiInit(u8 eqNo, u8 unitNo, u8 channelNo, char *deviceName)
     hp = gethostbyname(feip->serverName);
     if (hp == NULL)
         {
-        fprintf(stderr, "(crayfei) Failed to lookup address of Cray computer simulator host %s\n", feip->serverName);
+        logDtError(LogErrorLocation, "Failed to lookup address of Cray computer simulator host %s\n", feip->serverName);
         exit(1);
         }
     feip->serverAddr.sin_family = AF_INET;
@@ -407,20 +407,22 @@ void csFeiShowStatus()
         ipAddr = ntohl(feip->serverAddr.sin_addr.s_addr);
         port   = ntohs(feip->serverAddr.sin_port);
         sprintf(peerAddress, "%d.%d.%d.%d:%d",
-          (ipAddr >> 24) & 0xff,
-          (ipAddr >> 16) & 0xff,
-          (ipAddr >>  8) & 0xff,
-          ipAddr         & 0xff,
-          port);
+                (ipAddr >> 24) & 0xff,
+                (ipAddr >> 16) & 0xff,
+                (ipAddr >> 8) & 0xff,
+                ipAddr & 0xff,
+                port);
 
         switch (feip->state)
             {
         case StCsFeiDisconnected:
-            sprintf(outBuf, FMTNETSTATUS"\n", ipAddress, peerAddress, "crs", "disconnected");
+            sprintf(outBuf, FMTNETSTATUS "\n", ipAddress, peerAddress, "crs", "disconnected");
             break;
+
         case StCsFeiConnecting:
-            sprintf(outBuf, FMTNETSTATUS"\n", netGetLocalTcpAddress(feip->fd), peerAddress, "crs", "connecting");
+            sprintf(outBuf, FMTNETSTATUS "\n", netGetLocalTcpAddress(feip->fd), peerAddress, "crs", "connecting");
             break;
+
         case StCsFeiSendLCP:
         case StCsFeiSendSubsegment:
         case StCsFeiRecvLCPLen:
@@ -429,8 +431,9 @@ void csFeiShowStatus()
         case StCsFeiRecvSubsegmentLen:
         case StCsFeiRecvSubsegment1:
         case StCsFeiRecvSubsegment2:
-            sprintf(outBuf, FMTNETSTATUS"\n", netGetLocalTcpAddress(feip->fd), netGetPeerTcpAddress(feip->fd), "crs", "connected");
+            sprintf(outBuf, FMTNETSTATUS "\n", netGetLocalTcpAddress(feip->fd), netGetPeerTcpAddress(feip->fd), "crs", "connected");
             break;
+
         default:
             strcpy(outBuf, "\n");
             break;
@@ -496,7 +499,7 @@ static void csFeiCheckStatus(FeiParam *feip)
         FD_SET(feip->fd, &writeFds);
         timeout.tv_sec  = 0;
         timeout.tv_usec = 0;
-        readySockets    = select(feip->fd + 1, NULL, &writeFds, NULL, &timeout);
+        readySockets    = select((int)(feip->fd + 1), NULL, &writeFds, NULL, &timeout);
         if ((readySockets > 0) && FD_ISSET(feip->fd, &writeFds))
             {
             csFeiReset(feip);
@@ -521,7 +524,7 @@ static void csFeiCheckStatus(FeiParam *feip)
             }
         timeout.tv_sec  = 0;
         timeout.tv_usec = 0;
-        readySockets    = select(feip->fd + 1, &readFds, &writeFds, NULL, &timeout);
+        readySockets    = select((int)(feip->fd + 1), &readFds, &writeFds, NULL, &timeout);
         if (readySockets > 0)
             {
             if (FD_ISSET(feip->fd, &readFds))
@@ -668,7 +671,6 @@ static void csFeiInitiateConnection(FeiParam *feip)
     int optVal;
 #endif
     int optEnable = 1;
-    int rc;
 
     currentTime = getSeconds();
     if (feip->nextConnectionAttempt > currentTime)
@@ -1026,14 +1028,14 @@ static void csFeiIo(void)
             break;
 
         default:
-            logError(LogErrorLocation, "channel %02o - invalid state: %d", activeChannel->id, feip->state);
+            logDtError(LogErrorLocation, "channel %02o - invalid state: %d", activeChannel->id, feip->state);
             break;
         }
         break;
 
     default:
-        logError(LogErrorLocation, "channel %02o - unsupported function code: %04o",
-                 activeChannel->id, activeDevice->fcode);
+        logDtError(LogErrorLocation, "channel %02o - unsupported function code: %04o",
+                   activeChannel->id, activeDevice->fcode);
         break;
         }
     }

--- a/cray_station.c
+++ b/cray_station.c
@@ -735,7 +735,7 @@ static void csFeiIo(void)
             {
             activeChannel->data = 0;
             switch (feip->state)
-            {
+                {
             case StCsFeiSendLCP:
             case StCsFeiSendSubsegment:
                 if (feip->outputBuffer.out < feip->outputBuffer.in)
@@ -758,7 +758,7 @@ static void csFeiIo(void)
 
             default:
                 break;
-            }
+                }
             activeDevice->fcode           = 0;
             activeChannel->discAfterInput = FALSE;
             activeChannel->full           = TRUE;
@@ -770,7 +770,7 @@ static void csFeiIo(void)
 
     case 0: /* I/O typically after FcCsFeiStatus function processed */
         switch (feip->state)
-        {
+            {
         case StCsFeiSendLCP:
             if (activeChannel->full == TRUE)
                 {
@@ -1030,7 +1030,7 @@ static void csFeiIo(void)
         default:
             logDtError(LogErrorLocation, "channel %02o - invalid state: %d", activeChannel->id, feip->state);
             break;
-        }
+            }
         break;
 
     default:

--- a/dcc6681.c
+++ b/dcc6681.c
@@ -125,7 +125,7 @@ DevSlot *dcc6681Attach(u8 channelNo, u8 eqNo, u8 unitNo, u8 devType)
         cp = (DccControl *)calloc(1, sizeof(DccControl));
         if (cp == NULL)
             {
-            fprintf(stderr, "(dcc6681) Failed to allocate dcc6681 context block\n");
+            logDtError(LogErrorLocation, "Failed to allocate dcc6681 context block\n");
             exit(1);
             }
 
@@ -146,7 +146,7 @@ DevSlot *dcc6681Attach(u8 channelNo, u8 eqNo, u8 unitNo, u8 devType)
         device = calloc(1, sizeof(DevSlot));
         if (device == NULL)
             {
-            fprintf(stderr, "(dcc6681) Failed to allocate device control block for converter on channel %d\n", channelNo);
+            logDtError(LogErrorLocation, "Failed to allocate device control block for converter on channel %d\n", channelNo);
             exit(1);
             }
 
@@ -420,11 +420,13 @@ static FcStatus dcc6681Func(PpWord funcCode)
         if (rc == FcDeclined)
             {
             mp->status = StFc6681Reject;
+
             return FcProcessed;
             }
         else
             {
             mp->status = StFc6681Ready;
+
             return rc;
             }
         }

--- a/dd6603.c
+++ b/dd6603.c
@@ -269,7 +269,7 @@ void dd6603Init(u8 eqNo, u8 unitNo, u8 channelNo, char *deviceName)
 
     if (dp->context[unitNo] == NULL)
         {
-        fprintf(stderr, "(dd6603 ) Failed to allocate context block\n");
+        logDtError(LogErrorLocation, "Failed to allocate context block\n");
         exit(1);
         }
 
@@ -280,7 +280,10 @@ void dd6603Init(u8 eqNo, u8 unitNo, u8 channelNo, char *deviceName)
     else
         {
         opt = strchr(deviceName, ',');
-        if (opt != NULL) *opt++ = '\0';
+        if (opt != NULL)
+            {
+            *opt++ = '\0';
+            }
         strcpy(fname, deviceName);
         }
 
@@ -290,7 +293,7 @@ void dd6603Init(u8 eqNo, u8 unitNo, u8 channelNo, char *deviceName)
         fcb = fopen(fname, "w+b");
         if (fcb == NULL)
             {
-            fprintf(stderr, "(dd6603 ) Failed to open '%s'\n", fname);
+            logDtError(LogErrorLocation, "Failed to open '%s'\n", fname);
             exit(1);
             }
         }
@@ -428,7 +431,7 @@ static void dd6603Io(void)
     switch (activeDevice->fcode & Fc6603CodeMask)
         {
     default:
-        logError(LogErrorLocation, "(dd6603 ) channel %02o - invalid function code: %4.4o", activeChannel->id, (u32)activeDevice->fcode);
+        logDtError(LogErrorLocation, "channel %02o - invalid function code: %4.4o", activeChannel->id, (u32)activeDevice->fcode);
         break;
 
     case 0:
@@ -437,7 +440,7 @@ static void dd6603Io(void)
     case Fc6603ReadSector:
         if (!activeChannel->full)
             {
-            ignore = fread(&activeChannel->data, 2, 1, fcb);
+            ignore = (int)fread(&activeChannel->data, 2, 1, fcb);
             activeChannel->full = TRUE;
 
 #if DEBUG
@@ -526,21 +529,21 @@ static i32 dd6603Seek(i32 track, i32 head, i32 sector)
 
     if (track >= MaxTracks)
         {
-        logError(LogErrorLocation, "(dd6603 ) ch %o, track %o invalid", activeChannel->id, track);
+        logDtError(LogErrorLocation, "ch %o, track %o invalid", activeChannel->id, track);
 
         return (-1);
         }
 
     if (head >= MaxHeads)
         {
-        logError(LogErrorLocation, "(dd6603 ) ch %o, head %o invalid", activeChannel->id, head);
+        logDtError(LogErrorLocation, "ch %o, head %o invalid", activeChannel->id, head);
 
         return (-1);
         }
 
     if (sector >= sectorsPerTrack)
         {
-        logError(LogErrorLocation, "(dd6603 ) ch %o, sector %o invalid", activeChannel->id, sector);
+        logDtError(LogErrorLocation, "ch %o, sector %o invalid", activeChannel->id, sector);
 
         return (-1);
         }
@@ -602,7 +605,7 @@ static char *dd6603Func2String(PpWord funcCode)
 void dd6603ShowDiskStatus()
     {
     DiskParam *dp = firstDisk;
-    char      outBuf[MaxFSPath+128];
+    char      outBuf[MaxFSPath + 128];
 
     if (dp == NULL)
         {

--- a/dd885-42.c
+++ b/dd885-42.c
@@ -704,7 +704,7 @@ static void dd885_42Io(void)
         if (activeChannel->full)
             {
             switch (activeDevice->recordLength--)
-            {
+                {
             case 4:
                 unitNo = activeChannel->data & 07;
                 if (unitNo != activeDevice->selectedUnit)
@@ -761,7 +761,7 @@ static void dd885_42Io(void)
             default:
                 activeDevice->recordLength = 0;
                 break;
-            }
+                }
 
 #if DEBUG
             fprintf(dd885_42Log, " %04o[%d]", activeChannel->data, activeChannel->data);
@@ -777,7 +777,7 @@ static void dd885_42Io(void)
             if (dp != NULL)
                 {
                 switch (activeDevice->recordLength--)
-                {
+                    {
                 case 2:
                     dp->emAddress[0] = activeChannel->data;
                     break;
@@ -797,7 +797,7 @@ static void dd885_42Io(void)
                 default:
                     activeDevice->recordLength = 0;
                     break;
-                }
+                    }
                 }
 #if DEBUG
             fprintf(dd885_42Log, " %04o", activeChannel->data);
@@ -813,7 +813,7 @@ static void dd885_42Io(void)
             if (dp != NULL)
                 {
                 switch (activeDevice->recordLength--)
-                {
+                    {
                 case 6:
                     dp->emAddress[0] = activeChannel->data;
                     break;
@@ -849,7 +849,7 @@ static void dd885_42Io(void)
                 default:
                     activeDevice->recordLength = 0;
                     break;
-                }
+                    }
                 }
 
 #if DEBUG

--- a/dd885-42.c
+++ b/dd885-42.c
@@ -271,7 +271,7 @@ void dd885_42Init(u8 eqNo, u8 unitNo, u8 channelNo, char *deviceName)
 
     if (extMaxMemory == 0)
         {
-        fprintf(stderr, "(dd885-42) Cannot configure 885-42 disk, no ECS configured\n");
+        logDtError(LogErrorLocation, "Cannot configure 885-42 disk, no ECS configured\n");
         exit(1);
         }
 
@@ -281,7 +281,7 @@ void dd885_42Init(u8 eqNo, u8 unitNo, u8 channelNo, char *deviceName)
         dd885_42Log = fopen("dd885_42log.txt", "wt");
         if (dd885_42Log == NULL)
             {
-            fprintf(stderr, "dd885_42log.txt - aborting\n");
+            logDtError(LogErrorLocation, "Cannot Open dd885_42log.txt - aborting\n");
             exit(1);
             }
         }
@@ -304,7 +304,7 @@ void dd885_42Init(u8 eqNo, u8 unitNo, u8 channelNo, char *deviceName)
     dp = (DiskParam *)calloc(1, sizeof(DiskParam));
     if (dp == NULL)
         {
-        fprintf(stderr, "(dd885-42) Failed to allocate dd885_42 context block\n");
+        logDtError(LogErrorLocation, "Failed to allocate dd885_42 context block\n");
         exit(1);
         }
 
@@ -324,7 +324,7 @@ void dd885_42Init(u8 eqNo, u8 unitNo, u8 channelNo, char *deviceName)
         **  Process options.
         */
         *opt++ = '\0';
-        fprintf(stderr, "(dd885-42) Unrecognized option name %s\n", opt);
+        logDtError(LogErrorLocation, "Unrecognized option name %s\n", opt);
         exit(1);
         }
 
@@ -398,7 +398,7 @@ void dd885_42Init(u8 eqNo, u8 unitNo, u8 channelNo, char *deviceName)
         fcb = fopen(fname, "w+b");
         if (fcb == NULL)
             {
-            fprintf(stderr, "(dd885-42) Failed to open %s\n", fname);
+            logDtError(LogErrorLocation, "Failed to open %s\n", fname);
             exit(1);
             }
 
@@ -643,7 +643,7 @@ static FcStatus dd885_42Func(PpWord funcCode)
 #if DEBUG
         fprintf(dd885_42Log, " !!!!!FUNC %s not implemented but accepted!!!!!! ", dd885_42Func2String(funcCode));
 #endif
-        logError(LogErrorLocation, "ch %o, function %s not implemented\n", activeChannel->id, dd885_42Func2String(funcCode));
+        logDtError(LogErrorLocation, "ch %o, function %s not implemented\n", activeChannel->id, dd885_42Func2String(funcCode));
         break;
 
     case Fc885_42InterlockAutoload:
@@ -654,7 +654,7 @@ static FcStatus dd885_42Func(PpWord funcCode)
     case Fc885_42ReadFactoryData:
     case Fc885_42ReadUtilityMap:
     case Fc885_42ReadProtectedSector:
-        ignore = fread(&dp->buffer, sizeof dp->buffer, 1, fcb);
+        ignore = (int)fread(&dp->buffer, sizeof dp->buffer, 1, fcb);
         activeDevice->recordLength = ShortSectorSize * 5 + 2;
         break;
         }
@@ -717,8 +717,8 @@ static void dd885_42Io(void)
                         }
                     else
                         {
-                        logError(LogErrorLocation, "channel %02o - invalid select: %4.4o",
-                                 activeChannel->id, (u32)activeDevice->fcode);
+                        logDtError(LogErrorLocation, "channel %02o - invalid select: %4.4o",
+                                   activeChannel->id, (u32)activeDevice->fcode);
                         activeDevice->selectedUnit = -1;
                         }
                     }
@@ -1048,7 +1048,7 @@ static i32 dd885_42Seek(DiskParam *dp)
 #if DEBUG
         fprintf(dd885_42Log, "ch %o, cylinder %d invalid\n", activeChannel->id, dp->cylinder);
 #endif
-        logError(LogErrorLocation, "ch %o, cylinder %d invalid\n", activeChannel->id, dp->cylinder);
+        logDtError(LogErrorLocation, "ch %o, cylinder %d invalid\n", activeChannel->id, dp->cylinder);
         activeDevice->status   = St885_42Abnormal | St885_42NonrecoverableError;
         dp->detailedStatus[2] |= 0010;
 
@@ -1060,7 +1060,7 @@ static i32 dd885_42Seek(DiskParam *dp)
 #if DEBUG
         fprintf(dd885_42Log, "ch %o, track %d invalid\n", activeChannel->id, dp->track);
 #endif
-        logError(LogErrorLocation, "ch %o, track %d invalid\n", activeChannel->id, dp->track);
+        logDtError(LogErrorLocation, "ch %o, track %d invalid\n", activeChannel->id, dp->track);
         activeDevice->status   = St885_42Abnormal | St885_42NonrecoverableError;
         dp->detailedStatus[2] |= 0010;
 
@@ -1072,7 +1072,7 @@ static i32 dd885_42Seek(DiskParam *dp)
 #if DEBUG
         fprintf(dd885_42Log, "ch %o, sector %d invalid\n", activeChannel->id, dp->sector);
 #endif
-        logError(LogErrorLocation, "ch %o, sector %d invalid\n", activeChannel->id, dp->sector);
+        logDtError(LogErrorLocation, "ch %o, sector %d invalid\n", activeChannel->id, dp->sector);
         activeDevice->status   = St885_42Abnormal | St885_42NonrecoverableError;
         dp->detailedStatus[2] |= 0010;
 
@@ -1135,7 +1135,7 @@ static bool dd885_42Read(DiskParam *dp, FILE *fcb)
     activeDevice->status  = 0;
     dp->detailedStatus[2] = Fc885_42Read << 4;
 
-    ignore = fread(&dp->buffer, sizeof dp->buffer, 1, fcb);
+    ignore = (int)fread(&dp->buffer, sizeof dp->buffer, 1, fcb);
     activeDevice->status = 0;
     dp->generalStatus[3] = dp->buffer.control[0];
     dp->generalStatus[4] = dp->buffer.control[1];
@@ -1164,7 +1164,7 @@ static bool dd885_42Read(DiskParam *dp, FILE *fcb)
         }
     else
         {
-        logError(LogErrorLocation, "ch %o, ECS transfer from 885-42 rejected, address: %08o\n", activeChannel->id, emAddress);
+        logDtError(LogErrorLocation, "ch %o, ECS transfer from 885-42 rejected, address: %08o\n", activeChannel->id, emAddress);
         activeDevice->status   = St885_42Abnormal | St885_42NonrecoverableError;
         dp->detailedStatus[2] |= 0010;
 
@@ -1223,7 +1223,7 @@ static bool dd885_42Write(DiskParam *dp, FILE *fcb)
         }
     else
         {
-        logError(LogErrorLocation, "ch %o, ECS transfer from 885-42 rejected, address: %08o\n", activeChannel->id, emAddress);
+        logDtError(LogErrorLocation, "ch %o, ECS transfer from 885-42 rejected, address: %08o\n", activeChannel->id, emAddress);
         activeDevice->status   = St885_42Abnormal | St885_42NonrecoverableError;
         dp->detailedStatus[2] |= 0010;
 
@@ -1306,7 +1306,7 @@ static char *dd885_42Func2String(PpWord funcCode)
 void dd885_42ShowDiskStatus()
     {
     DiskParam *dp = firstDisk;
-    char      outBuf[MaxFSPath+128];
+    char      outBuf[MaxFSPath + 128];
 
     if (dp == NULL)
         {

--- a/dd8xx.c
+++ b/dd8xx.c
@@ -1133,7 +1133,7 @@ static FcStatus dd8xxFunc(PpWord funcCode)
             dp->detailedStatus[2] = (funcCode << 4) & 07760;
 
             switch (dp->diskType)
-            {
+                {
             case DiskType885:
                 dp->detailedStatus[4] = (dp->cylinder >> 4) & 077;
                 dp->detailedStatus[5] = ((dp->cylinder << 8) | dp->track) & 07777;
@@ -1169,7 +1169,7 @@ static FcStatus dd8xxFunc(PpWord funcCode)
                     dp->detailedStatus[8] &= ~0300;
                     }
                 break;
-            }
+                }
             }
         else
             {
@@ -1199,7 +1199,7 @@ static FcStatus dd8xxFunc(PpWord funcCode)
 
     case Fc8xxDeadstart:
         switch (dp->diskType)
-        {
+            {
         case DiskType844:
             if (dp->size.maxCylinders == MaxCylinders844_2)
                 {
@@ -1219,7 +1219,7 @@ static FcStatus dd8xxFunc(PpWord funcCode)
             dp->track    = DsTrack885;
             dp->sector   = DsSector885;
             break;
-        }
+            }
 
         fseek(fcb, dd8xxSeek(dp), SEEK_SET);
         activeDevice->recordLength = SectorSize;
@@ -1338,7 +1338,7 @@ static void dd8xxIo(void)
         if (activeChannel->full)
             {
             switch (activeDevice->recordLength--)
-            {
+                {
             case 4:
                 unitNo = activeChannel->data & 07;
                 if (unitNo != activeDevice->selectedUnit)
@@ -1408,7 +1408,7 @@ static void dd8xxIo(void)
             default:
                 activeDevice->recordLength = 0;
                 break;
-            }
+                }
 
 #if DEBUG
             fprintf(dd8xxLog, " %04o[%d]", activeChannel->data, activeChannel->data);

--- a/dd8xx.c
+++ b/dd8xx.c
@@ -328,6 +328,7 @@ static FILE *dd8xxLog = NULL;
 #if DEBUG
 static void dd8xxLogFlush(void);
 static void dd8xxLogByte(int b);
+
 #endif
 
 #if DEBUG
@@ -454,6 +455,7 @@ void dd8xxLoadDisk(char *params)
     if (numParam != 4)
         {
         opDisplay("(dd8xx  ) Not enough or invalid parameters\n");
+
         return;
         }
 
@@ -495,6 +497,7 @@ void dd8xxLoadDisk(char *params)
         {
         sprintf(outBuf, "(dd8xx  ) Unit %d not allocated\n", unitNo);
         opDisplay(outBuf);
+
         return;
         }
 
@@ -505,6 +508,7 @@ void dd8xxLoadDisk(char *params)
         {
         sprintf(outBuf, "(dd8xx  ) Unit %d not unloaded\n", unitNo);
         opDisplay(outBuf);
+
         return;
         }
 
@@ -517,6 +521,7 @@ void dd8xxLoadDisk(char *params)
         {
         sprintf(outBuf, "(dd8xx  ) Failed to open %s\n", str);
         opDisplay(outBuf);
+
         return;
         }
 
@@ -596,6 +601,7 @@ void dd8xxUnloadDisk(char *params)
         {
         sprintf(outBuf, "(dd8xx  ) Unit %d not allocated\n", unitNo);
         opDisplay(outBuf);
+
         return;
         }
 
@@ -606,6 +612,7 @@ void dd8xxUnloadDisk(char *params)
         {
         sprintf(outBuf, "(dd8xx  ) Unit %d not loaded\n", unitNo);
         opDisplay(outBuf);
+
         return;
         }
 
@@ -661,7 +668,7 @@ static void dd8xxInit(u8 eqNo, u8 unitNo, u8 channelNo, char *deviceName, DiskSi
         dd8xxLog = fopen("dd8xxlog.txt", "wt");
         if (dd8xxLog == NULL)
             {
-            fprintf(stderr, "dd8xxlog.txt - aborting\n");
+            logDtError(LogErrorLocation, "Cannot Open dd8xxlog.txt - aborting\n");
             exit(1);
             }
         }
@@ -684,7 +691,7 @@ static void dd8xxInit(u8 eqNo, u8 unitNo, u8 channelNo, char *deviceName, DiskSi
     dp = (DiskParam *)calloc(1, sizeof(DiskParam));
     if (dp == NULL)
         {
-        fprintf(stderr, "(dd8xx  ) Failed to allocate dd8xx context block\n");
+        logDtError(LogErrorLocation, "Failed to allocate dd8xx context block\n");
         exit(1);
         }
 
@@ -722,7 +729,8 @@ static void dd8xxInit(u8 eqNo, u8 unitNo, u8 channelNo, char *deviceName, DiskSi
             }
         else
             {
-            fprintf(stderr, "(dd8xx  ) Unrecognized option name %s\n", opt);
+            logDtError(LogErrorLocation, "Unrecognized option name %s\n", opt);
+
             exit(1);
             }
         }
@@ -796,7 +804,7 @@ static void dd8xxInit(u8 eqNo, u8 unitNo, u8 channelNo, char *deviceName, DiskSi
 
     lastDisk = dp;
 
-    if (deviceName != NULL && strcmp(deviceName, "*") == 0)
+    if ((deviceName != NULL) && (strcmp(deviceName, "*") == 0))
         {
         ds->fcb[unitNo] = NULL;
         printf("(dd8xx  ) Removable disk initialised on channel %o equip %o unit %o\n", channelNo, eqNo, unitNo);
@@ -813,7 +821,7 @@ static void dd8xxInit(u8 eqNo, u8 unitNo, u8 channelNo, char *deviceName, DiskSi
             }
         ds->fcb[unitNo] = fcb;
         printf("(dd8xx  ) Disk with %d cylinders initialised on channel %o equip %o unit %o filename '%s'\n",
-           dp->size.maxCylinders, channelNo, eqNo, unitNo, dp->fileName);
+               dp->size.maxCylinders, channelNo, eqNo, unitNo, dp->fileName);
         }
     }
 
@@ -831,7 +839,7 @@ static FILE *dd8xxMount(char *deviceName, DiskParam *dp)
     {
     FILE      *fcb;
     char      fname[MaxFSPath];
-    char      msg[MaxFSPath+30];
+    char      msg[MaxFSPath + 30];
     time_t    mTime;
     struct tm *lTime;
     u8        yy, mm, dd;
@@ -874,6 +882,7 @@ static FILE *dd8xxMount(char *deviceName, DiskParam *dp)
             {
             sprintf(msg, "(dd8xx  ) Failed to open %s\n", fname);
             opDisplay(msg);
+
             return NULL;
             }
 
@@ -1124,7 +1133,7 @@ static FcStatus dd8xxFunc(PpWord funcCode)
             dp->detailedStatus[2] = (funcCode << 4) & 07760;
 
             switch (dp->diskType)
-                {
+            {
             case DiskType885:
                 dp->detailedStatus[4] = (dp->cylinder >> 4) & 077;
                 dp->detailedStatus[5] = ((dp->cylinder << 8) | dp->track) & 07777;
@@ -1160,7 +1169,7 @@ static FcStatus dd8xxFunc(PpWord funcCode)
                     dp->detailedStatus[8] &= ~0300;
                     }
                 break;
-                }
+            }
             }
         else
             {
@@ -1251,7 +1260,7 @@ static FcStatus dd8xxFunc(PpWord funcCode)
 #if DEBUG
         fprintf(dd8xxLog, " !!!!!FUNC not implemented but accepted!!!!!! ");
 #endif
-        logError(LogErrorLocation, "(dd8xx  ) ch %o, function %04o not implemented\n", activeChannel->id, funcCode);
+        logDtError(LogErrorLocation, "ch %o, function %04o not implemented\n", activeChannel->id, funcCode);
         break;
         }
 
@@ -1300,15 +1309,15 @@ static void dd8xxIo(void)
             if (unitNo != activeDevice->selectedUnit)
                 {
                 dp = (DiskParam *)activeDevice->context[unitNo];
-                if (dp != NULL && activeDevice->fcb[unitNo] != NULL)
+                if ((dp != NULL) && (activeDevice->fcb[unitNo] != NULL))
                     {
                     activeDevice->selectedUnit = unitNo;
-                    dp->detailedStatus[12] &= ~01000;
+                    dp->detailedStatus[12]    &= ~01000;
                     }
                 else
                     {
                     activeDevice->selectedUnit = -1;
-                    activeDevice->status = 05020;
+                    activeDevice->status       = 05020;
                     }
                 }
             else if (fcb != NULL)
@@ -1318,7 +1327,7 @@ static void dd8xxIo(void)
             else
                 {
                 activeDevice->selectedUnit = -1;
-                activeDevice->status = 05020;
+                activeDevice->status       = 05020;
                 }
             activeChannel->full = FALSE;
             }
@@ -1334,16 +1343,16 @@ static void dd8xxIo(void)
                 unitNo = activeChannel->data & 07;
                 if (unitNo != activeDevice->selectedUnit)
                     {
-                    dp  = (DiskParam *)activeDevice->context[unitNo];
-                    if (dp != NULL && activeDevice->fcb[unitNo] != NULL)
+                    dp = (DiskParam *)activeDevice->context[unitNo];
+                    if ((dp != NULL) && (activeDevice->fcb[unitNo] != NULL))
                         {
                         activeDevice->selectedUnit = unitNo;
-                        dp->detailedStatus[12] &= ~01000;
+                        dp->detailedStatus[12]    &= ~01000;
                         }
                     else
                         {
                         activeDevice->selectedUnit = -1;
-                        activeDevice->status = 05020;
+                        activeDevice->status       = 05020;
                         }
                     }
                 else if (fcb != NULL)
@@ -1353,7 +1362,7 @@ static void dd8xxIo(void)
                 else
                     {
                     activeDevice->selectedUnit = -1;
-                    activeDevice->status = 05020;
+                    activeDevice->status       = 05020;
                     }
                 break;
 
@@ -1697,7 +1706,7 @@ static i32 dd8xxSeek(DiskParam *dp)
 #if DEBUG
         fprintf(dd8xxLog, "(dd8xx  ) ch %o, cylinder %d invalid\n", activeChannel->id, dp->cylinder);
 #endif
-        logError(LogErrorLocation, "(dd8xx  ) ch %o, cylinder %d invalid\n", activeChannel->id, dp->cylinder);
+        logDtError(LogErrorLocation, "ch %o, cylinder %d invalid\n", activeChannel->id, dp->cylinder);
         dp->device->status = 01000;
 
         return (-1);
@@ -1708,7 +1717,7 @@ static i32 dd8xxSeek(DiskParam *dp)
 #if DEBUG
         fprintf(dd8xxLog, "(dd8xx  ) ch %o, track %d invalid\n", activeChannel->id, dp->track);
 #endif
-        logError(LogErrorLocation, "(dd8xx  ) ch %o, track %d invalid\n", activeChannel->id, dp->track);
+        logDtError(LogErrorLocation, "ch %o, track %d invalid\n", activeChannel->id, dp->track);
         dp->device->status = 01000;
 
         return (-1);
@@ -1719,7 +1728,7 @@ static i32 dd8xxSeek(DiskParam *dp)
 #if DEBUG
         fprintf(dd8xxLog, "(dd8xx  ) ch %o, sector %d invalid\n", activeChannel->id, dp->sector);
 #endif
-        logError(LogErrorLocation, "(dd8xx  ) ch %o, sector %d invalid\n", activeChannel->id, dp->sector);
+        logDtError(LogErrorLocation, "ch %o, sector %d invalid\n", activeChannel->id, dp->sector);
         dp->device->status = 01000;
 
         return (-1);
@@ -1818,7 +1827,7 @@ static PpWord dd8xxReadClassic(DiskParam *dp, FILE *fcb)
     if (dp->bufPtr == NULL)
         {
         dp->bufPtr = dp->buffer;
-        ignore     = fread(dp->buffer, 1, dp->sectorSize, fcb);
+        ignore     = (int)fread(dp->buffer, 1, dp->sectorSize, fcb);
         }
 
     /*
@@ -1896,7 +1905,7 @@ static PpWord dd8xxReadPacked(DiskParam *dp, FILE *fcb)
     if (dp->bufPtr == NULL)
         {
         dp->bufPtr = dp->buffer;
-        ignore     = fread(sector, 1, dp->sectorSize, fcb);
+        ignore     = (int)fread(sector, 1, dp->sectorSize, fcb);
 
         /*
         **  Unpack the sector into the buffer.
@@ -2080,7 +2089,7 @@ static void dd844SetClearFlaw(DiskParam *dp, PpWord flawState)
     dp->track    = 0;
     dp->sector   = 2;
     fseek(fcb, dd8xxSeek(dp), SEEK_SET);
-    ignore = fread(mySector, 2, SectorSize, fcb);
+    ignore = (int)fread(mySector, 2, SectorSize, fcb);
 
     /*
     **  Process request.
@@ -2276,7 +2285,7 @@ static char *dd8xxFunc2String(PpWord funcCode)
 void dd8xxShowDiskStatus()
     {
     DiskParam *dp = firstDisk;
-    char      outBuf[MaxFSPath+128];
+    char      outBuf[MaxFSPath + 128];
 
     if (dp == NULL)
         {

--- a/ddp.c
+++ b/ddp.c
@@ -155,7 +155,7 @@ void ddpInit(u8 eqNo, u8 unitNo, u8 channelNo, char *deviceName)
 
     if (extMaxMemory == 0)
         {
-        fprintf(stderr, "(ddp    ) Cannot configure DDP, no ECS configured\n");
+        logDtError(LogErrorLocation, "Cannot configure DDP, no ECS configured\n");
         exit(1);
         }
 
@@ -176,7 +176,7 @@ void ddpInit(u8 eqNo, u8 unitNo, u8 channelNo, char *deviceName)
     dc = calloc(1, sizeof(DdpContext));
     if (dc == NULL)
         {
-        fprintf(stderr, "(ddp    ) Failed to allocate DDP context block\n");
+        logDtError(LogErrorLocation, "Failed to allocate DDP context block\n");
         exit(1);
         }
 
@@ -338,7 +338,7 @@ static void ddpIo(void)
                     */
                     dc->endaddrcycle = cycles;
 
-                    if (extMemType == ECS || extMaxMemory <= 2*1024*1024)
+                    if ((extMemType == ECS) || (extMaxMemory <= 2 * 1024 * 1024))
                         {
                         isFlagReg = (dc->addr & DdpAddrFlagReg) != 0;
                         }
@@ -376,10 +376,10 @@ static void ddpIo(void)
                         {
                         dc->dbyte = -1;
 #if DEBUG
-                        if (extMemType == ECS || extMaxMemory <= 2*1024*1024)
+                        if ((extMemType == ECS) || (extMaxMemory <= 2 * 1024 * 1024))
                             {
                             isReadOne = (dc->addr & DdpAddrReadOne) != 0;
-                            isMaint   = (dc->addr & DdpAddrMaint)   != 0;
+                            isMaint   = (dc->addr & DdpAddrMaint) != 0;
                             }
                         else
                             {
@@ -406,10 +406,10 @@ static void ddpIo(void)
             {
             if (!activeChannel->full && (cycles - dc->endaddrcycle > 20))
                 {
-                if (extMemType == ECS || extMaxMemory <= 2*1024*1024)
+                if ((extMemType == ECS) || (extMaxMemory <= 2 * 1024 * 1024))
                     {
                     isReadOne = (dc->addr & DdpAddrReadOne) != 0;
-                    isMaint   = (dc->addr & DdpAddrMaint)   != 0;
+                    isMaint   = (dc->addr & DdpAddrMaint) != 0;
                     addr      = dc->addr & Mask21;
                     }
                 else
@@ -481,7 +481,7 @@ static void ddpIo(void)
                 /*
                 **  Write next 60 bit to ECS.
                 */
-                if (activeDevice->fcode != FcDdpMaintModeWrite && !cpuDdpTransfer(dc->addr, &dc->curword, TRUE))
+                if ((activeDevice->fcode != FcDdpMaintModeWrite) && !cpuDdpTransfer(dc->addr, &dc->curword, TRUE))
                     {
 #if DEBUG
                     fputs(" abort", ddpLog);

--- a/dsa311.c
+++ b/dsa311.c
@@ -681,7 +681,7 @@ static void dsa311Io(void)
             else // output data port
                 {
                 switch (cp->outputState)
-                {
+                    {
                 //
                 //  Look for beginning of a message, and discard characters
                 //  until SOH or DLE is seen.
@@ -736,7 +736,7 @@ static void dsa311Io(void)
                     if (cp->sktOutBuf.in + 1 < SktOutBufSize)
                         {
                         switch (ch)
-                        {
+                            {
                         case SYN:
                             // discard trailing SYN's
                             break;
@@ -756,7 +756,7 @@ static void dsa311Io(void)
                         default:
                             cp->sktOutBuf.data[cp->sktOutBuf.in++] = ch;
                             break;
-                        }
+                            }
                         }
                     break;
 
@@ -820,7 +820,7 @@ static void dsa311Io(void)
 #endif
                     cp->outputState = StDsa311OutSOH;
                     break;
-                }
+                    }
                 }
             activeChannel->full = FALSE;
             }

--- a/dsa311.c
+++ b/dsa311.c
@@ -305,20 +305,20 @@ void dsa311Init(u8 eqNo, u8 unitNo, u8 channelNo, char *params)
         }
     if (unitNo >= MaxUnits2)
         {
-        fprintf(stderr, "(dsa311 ) Unit number must be less than %o for DSA311 on channel %o equipment %o unit %o\n",
-                MaxUnits2, channelNo, eqNo, unitNo);
+        logDtError(LogErrorLocation, "Unit number must be less than %o for DSA311 on channel %o equipment %o unit %o\n",
+                   MaxUnits2, channelNo, eqNo, unitNo);
         exit(1);
         }
     if ((unitNo & 1) != 0)
         {
-        fprintf(stderr, "(dsa311 ) Unit number must be even for DSA311 on channel %o equipment %o unit %o\n",
-                channelNo, eqNo, unitNo);
+        logDtError(LogErrorLocation, "Unit number must be even for DSA311 on channel %o equipment %o unit %o\n",
+                   channelNo, eqNo, unitNo);
         exit(1);
         }
     if (params == NULL)
         {
-        fprintf(stderr, "(dsa311 ) HASP host connection information required for DSA311 on channel %o equipment %o unit %o\n",
-                channelNo, eqNo, unitNo);
+        logDtError(LogErrorLocation, "HASP host connection information required for DSA311 on channel %o equipment %o unit %o\n",
+                   channelNo, eqNo, unitNo);
         exit(1);
         }
 
@@ -326,8 +326,8 @@ void dsa311Init(u8 eqNo, u8 unitNo, u8 channelNo, char *params)
 
     if (dp->context[unitNo] != NULL)
         {
-        fprintf(stderr, "(dsa311 ) Duplicate DSA311 unit number %o on channel %o equipment %o\n",
-                unitNo, channelNo, eqNo);
+        logDtError(LogErrorLocation, "Duplicate DSA311 unit number %o on channel %o equipment %o\n",
+                   unitNo, channelNo, eqNo);
         exit(1);
         }
 
@@ -339,7 +339,7 @@ void dsa311Init(u8 eqNo, u8 unitNo, u8 channelNo, char *params)
     cp = (Dsa311Context *)calloc(1, sizeof(Dsa311Context));
     if (cp == NULL)
         {
-        fprintf(stderr, "(dsa311 ) Failed to allocate DSA311 context block\n");
+        logDtError(LogErrorLocation, "Failed to allocate DSA311 context block\n");
         exit(1);
         }
     if (firstMux == NULL)
@@ -367,7 +367,7 @@ void dsa311Init(u8 eqNo, u8 unitNo, u8 channelNo, char *params)
     cp->sktOutBuf.data = (u8 *)calloc(1, SktOutBufSize);
     if ((cp->ppInBuf.data == NULL) || (cp->sktInBuf.data == NULL) || (cp->sktOutBuf.data == NULL))
         {
-        fprintf(stderr, "(dsa311 ) Failed to allocate DSA311 I/O buffer\n");
+        logDtError(LogErrorLocation, "Failed to allocate DSA311 I/O buffer\n");
         exit(1);
         }
     dsa311Reset(cp);
@@ -397,7 +397,7 @@ void dsa311Init(u8 eqNo, u8 unitNo, u8 channelNo, char *params)
     hp = gethostbyname(serverName);
     if (hp == NULL)
         {
-        fprintf(stderr, "(dsa311 ) Failed to lookup address of DSA311 HASP host %s\n", serverName);
+        logDtError(LogErrorLocation, "Failed to lookup address of DSA311 HASP host %s\n", serverName);
         exit(1);
         }
     cp->serverAddr.sin_family = AF_INET;
@@ -435,23 +435,26 @@ void dsa311ShowStatus()
         ipAddr = ntohl(cp->serverAddr.sin_addr.s_addr);
         port   = ntohs(cp->serverAddr.sin_port);
         sprintf(peerAddress, "%d.%d.%d.%d:%d",
-          (ipAddr >> 24) & 0xff,
-          (ipAddr >> 16) & 0xff,
-          (ipAddr >>  8) & 0xff,
-          ipAddr         & 0xff,
-          port);
+                (ipAddr >> 24) & 0xff,
+                (ipAddr >> 16) & 0xff,
+                (ipAddr >> 8) & 0xff,
+                ipAddr & 0xff,
+                port);
 
         switch (cp->majorState)
             {
         case StDsa311MajDisconnected:
-            sprintf(outBuf, FMTNETSTATUS"\n", ipAddress, peerAddress, "rhasp", "disconnected");
+            sprintf(outBuf, FMTNETSTATUS "\n", ipAddress, peerAddress, "rhasp", "disconnected");
             break;
+
         case StDsa311MajConnecting:
-            sprintf(outBuf, FMTNETSTATUS"\n", netGetLocalTcpAddress(cp->fd), peerAddress, "rhasp", "connecting");
+            sprintf(outBuf, FMTNETSTATUS "\n", netGetLocalTcpAddress(cp->fd), peerAddress, "rhasp", "connecting");
             break;
+
         case StDsa311MajConnected:
-            sprintf(outBuf, FMTNETSTATUS"\n", netGetLocalTcpAddress(cp->fd), netGetPeerTcpAddress(cp->fd), "rhasp", "connected");
+            sprintf(outBuf, FMTNETSTATUS "\n", netGetLocalTcpAddress(cp->fd), netGetPeerTcpAddress(cp->fd), "rhasp", "connected");
             break;
+
         default:
             strcpy(outBuf, "\n");
             break;
@@ -904,7 +907,7 @@ static void dsa311CheckIo(Dsa311Context *cp)
         FD_SET(cp->fd, &writeFds);
         timeout.tv_sec  = 0;
         timeout.tv_usec = 0;
-        n = select(cp->fd + 1, NULL, &writeFds, NULL, &timeout);
+        n = select((int)(cp->fd + 1), NULL, &writeFds, NULL, &timeout);
         if (n <= 0)
             {
 #if DEBUG
@@ -958,12 +961,12 @@ static void dsa311CheckIo(Dsa311Context *cp)
     if (cp->sktInBuf.in < SktInBufSize)
         {
         FD_SET(cp->fd, &readFds);
-        maxFd = cp->fd;
+        maxFd = (int)cp->fd;
         }
     if (cp->sktOutBuf.out < cp->sktOutBuf.in)
         {
         FD_SET(cp->fd, &writeFds);
-        maxFd = cp->fd;
+        maxFd = (int)cp->fd;
         }
     if (maxFd == 0)
         {
@@ -1038,6 +1041,7 @@ static void dsa311InitiateConnection(Dsa311Context *cp)
 #if DEBUG
         fprintf(dsa311Log, "\n%010lu failed to initiate connection", elapsedTime);
 #endif
+
         return;
         }
     else // connection in progress

--- a/dump.c
+++ b/dump.c
@@ -102,7 +102,7 @@ void dumpInit(void)
         cpuF[cp] = fopen(fileName, "wt");
         if (cpuF[cp] == NULL)
             {
-            logError(LogErrorLocation, "(dump   ) can't open cpu[%o] dump", cp);
+            logDtError(LogErrorLocation, "Can't open cpu[%o] dump", cp);
             }
         }
 
@@ -112,7 +112,7 @@ void dumpInit(void)
         ppuF[pp] = fopen(fileName, "wt");
         if (ppuF[pp] == NULL)
             {
-            logError(LogErrorLocation, "(dump   ) can't open ppu[%02o] dump", pp);
+            logDtError(LogErrorLocation, "can't open ppu[%02o] dump", pp);
             }
         }
     }
@@ -160,7 +160,7 @@ void dumpAll(void)
     u8 cp;
     u8 pp;
 
-    fprintf(stderr, "(dump   ) dumping core...");
+    logDtError(LogErrorLocation, "dumping core...");
     fflush(stderr);
 
     for (cp = 0; cp < cpuCount; cp++)
@@ -369,7 +369,7 @@ void dumpDisassemblePpu(u8 pp)
     pf = fopen(ppDisName, "wt");
     if (pf == NULL)
         {
-        logError(LogErrorLocation, "can't open %s", ppDisName);
+        logDtError(LogErrorLocation, "can't open %s", ppDisName);
 
         return;
         }
@@ -426,7 +426,7 @@ void dumpRunningPpu(u8 pp)
     pf = fopen(ppDumpName, "wt");
     if (pf == NULL)
         {
-        logError(LogErrorLocation, "(dump   ) can't open %s", ppDumpName);
+        logDtError(LogErrorLocation, "can't open %s", ppDumpName);
 
         return;
         }
@@ -457,7 +457,7 @@ void dumpRunningCpu(u8 cp)
     pf = fopen(cpDumpName, "wt");
     if (pf == NULL)
         {
-        logError(LogErrorLocation, "(dump   ) can't open %s", cpDumpName);
+        logDtError(LogErrorLocation, "can't open %s", cpDumpName);
 
         return;
         }

--- a/fsmon.c
+++ b/fsmon.c
@@ -199,7 +199,7 @@ bool fsCreateThread(fswContext *parms)
 
     if (noLaunch)
         {
-        fprintf(stderr, "(fsmon  ) Failed to create Filesystem Watcher thread\n");
+        logDtError(LogErrorLocation, "Failed to create Filesystem Watcher thread\n");
 
         return FALSE;
         }
@@ -234,7 +234,7 @@ static void *fsWatchThread(void * parms)
     int  retval           = 0;
     char lpDir[MaxFSPath] = { "" };
     //      Just need to be large enough to hold the unit spec.
-    char crDevId[16];
+    char crDevId[16] = "";
 
     struct dirent *curDirEntry;
     DIR           *curDir;
@@ -344,5 +344,6 @@ static void *fsWatchThread(void * parms)
     printf("(fsmon  ) Terminating Monitor Thread '%s'.\n", lparms->inWatchDir);
 
     free(lparms);
+
     return fsReturn;
     }

--- a/init.c
+++ b/init.c
@@ -61,7 +61,7 @@
 #define DefaultFontMedium      12
 #define DefaultFontSmall       8
 #else
-#define RGB(R,G,B) ((R<<16)|(G<<8)|B)
+#define RGB(R, G, B)    ((R << 16) | (G << 8) | B)
 #define FontName               "lucidatypewriter"
 #define DefaultFontLarge       24
 #define DefaultFontMedium      14
@@ -561,7 +561,7 @@ static void initCyber(char *config)
      */
     if (!initOpenSection(config))
         {
-        fprintf(stderr, "(init   ) Required section [%s] not found in %s\n", config, startupFile);
+        logDtError(LogErrorLocation, "Required section [%s] not found in %s\n", config, startupFile);
         exit(1);
         }
 
@@ -587,16 +587,16 @@ static void initCyber(char *config)
                     if (strcasecmp(curVal->valName, token) == 0)
                         {
                         goodToken = TRUE;
-                        fprintf(stderr, "(init   ) file '%s' section [%s] line %2d: %-12s %s\n",
-                                startupFile, config, lineNo, token == NULL ? "NULL" : token, curVal->valStatus);
+                        logDtError(LogErrorLocation, "file '%s' section [%s] line %2d: %-12s %s\n",
+                                   startupFile, config, lineNo, token == NULL ? "NULL" : token, curVal->valStatus);
                         break;
                         }
                     }
                 }
             if (!goodToken)
                 {
-                fprintf(stderr, "(init   ) file '%s' section [%s] line %2d: invalid or deprecated configuration keyword '%s'\n",
-                        startupFile, config, lineNo, token == NULL ? "NULL" : token);
+                logDtError(LogErrorLocation, "file '%s' section [%s] line %2d: invalid or deprecated configuration keyword '%s'\n",
+                           startupFile, config, lineNo, token == NULL ? "NULL" : token);
                 numErrors++;
                 }
             }
@@ -604,8 +604,8 @@ static void initCyber(char *config)
 
     if (numErrors > 0)
         {
-        fprintf(stderr, "(init   ) Correct the %d error(s) in section '[%s]' of '%s' and restart.\n",
-                numErrors, config, startupFile);
+        logDtError(LogErrorLocation, "Correct the %d error(s) in section '[%s]' of '%s' and restart.\n",
+                   numErrors, config, startupFile);
         exit(1);
         }
 
@@ -613,7 +613,7 @@ static void initCyber(char *config)
 
     if (!initOpenSection(config))
         {
-        fprintf(stderr, "(init   ) Required section [%s] not found in '%s'\n", config, startupFile);
+        logDtError(LogErrorLocation, "Required section [%s] not found in '%s'\n", config, startupFile);
         exit(1);
         }
     lineNo = 0;
@@ -623,28 +623,28 @@ static void initCyber(char *config)
     */
     if (initGetOctal("channels", 020, &chCount))
         {
-        fprintf(stderr, "(init   ) file '%s' section [%s]: ***WARNING*** Entry 'channels' is obsolete\n", startupFile, config);
-        fprintf(stderr, "                        channel count is determined from PP count.\n");
+        logDtError(LogErrorLocation, "file '%s' section [%s]: ***WARNING*** Entry 'channels' is obsolete\n", startupFile, config);
+        logDtError(LogErrorLocation, "                        channel count is determined from PP count.\n");
         exit(1);
         }
 
     if (initGetString("cmFile", "", dummy, sizeof(dummy)))
         {
-        fprintf(stderr, "(init   ) file '%s' section [%s]: ***WARNING*** Entry 'cmFile' is obsolete\n", startupFile, config);
-        fprintf(stderr, "                        please use 'persistDir' instead.\n");
+        logDtError(LogErrorLocation, "file '%s' section [%s]: ***WARNING*** Entry 'cmFile' is obsolete\n", startupFile, config);
+        logDtError(LogErrorLocation, "                        please use 'persistDir' instead.\n");
         exit(1);
         }
 
     if (initGetString("ecsFile", "", dummy, sizeof(dummy)))
         {
-        fprintf(stderr, "(init   ) file '%s' section [%s]: ***WARNING*** Entry 'ecsFile' is obsolete\n", startupFile, config);
-        fprintf(stderr, "                        please use 'persistDir' instead.\n");
+        logDtError(LogErrorLocation, "file '%s' section [%s]: ***WARNING*** Entry 'ecsFile' is obsolete\n", startupFile, config);
+        logDtError(LogErrorLocation, "                        please use 'persistDir' instead.\n");
         exit(1);
         }
 
     if (initGetString("displayName", "DtCyber Console", displayName, sizeof(displayName)))
         {
-        fprintf(stderr, "(init   ) Consoles will be labeled '%s',\n", displayName);
+        logDtError(LogErrorLocation, "Consoles will be labeled '%s',\n", displayName);
         }
 
     /*
@@ -676,8 +676,8 @@ static void initCyber(char *config)
         {
         //        modelType = ModelCyber840A;
         //        features = featuresCyber840A;
-        fprintf(stderr, "(init   ) file '%s' section [%s]: model CYBER840A was experimental and is no longer supported\n",
-            startupFile, config);
+        logDtError(LogErrorLocation, "file '%s' section [%s]: model CYBER840A was experimental and is no longer supported\n",
+                   startupFile, config);
         exit(1);
         }
     else if (stricmp(model, "CYBER865") == 0)
@@ -692,8 +692,8 @@ static void initCyber(char *config)
         }
     else
         {
-        fprintf(stderr, "(init   ) file '%s' section [%s]: 'model' specified unsupported mainframe type '%s'\n",
-            config, startupFile, model);
+        logDtError(LogErrorLocation, "file '%s' section [%s]: 'model' specified unsupported mainframe type '%s'\n",
+                   config, startupFile, model);
         exit(1);
         }
 
@@ -709,7 +709,7 @@ static void initCyber(char *config)
     (void)initGetOctal("memory", 01000000, &memory);
     if (memory < 040000)
         {
-        fprintf(stderr, "(init   ) file '%s' section [%s]: Entry 'memory' less than 40000B\n", startupFile, config);
+        logDtError(LogErrorLocation, "file '%s' section [%s]: Entry 'memory' less than 40000B\n", startupFile, config);
         exit(1);
         }
 
@@ -723,8 +723,8 @@ static void initCyber(char *config)
             && (memory != 014000000)
             && (memory != 020000000))
             {
-            fprintf(stderr, "(init   ) file '%s' section [%s]: Cyber 865 memory must be configured in 262K increments, and Cyber 875 memory must be configured in 1024K increments\n",
-                startupFile, config);
+            logDtError(LogErrorLocation, "file '%s' section [%s]: Cyber 865 memory must be configured in 262K increments, and Cyber 875 memory must be configured in 1024K increments\n",
+                       startupFile, config);
             exit(1);
             }
         if ((memory > 04000000) && ((features & IsCyber875) == 0))
@@ -753,7 +753,7 @@ static void initCyber(char *config)
         break;
 
     default:
-        fprintf(stderr, "(init   ) file '%s' section [%s]: Entry 'ecsbanks' invalid - correct values are 0, 1, 2, 4, 8 or 16\n", startupFile, config);
+        logDtError(LogErrorLocation, "file '%s' section [%s]: Entry 'ecsbanks' invalid - correct values are 0, 1, 2, 4, 8 or 16\n", startupFile, config);
         exit(1);
         }
 
@@ -773,27 +773,27 @@ static void initCyber(char *config)
     case 128:
         if (modelType != ModelCyber865)
             {
-            fprintf(stderr, "(init   ) WARNING - file '%s' section [%s]: Entry 'esmbanks' - only CPU models CYBER865 and CYBER875 can fully access more than 16 banks of ESM\n",
-                startupFile, config);
+            logDtError(LogErrorLocation, "WARNING - file '%s' section [%s]: Entry 'esmbanks' - only CPU models CYBER865 and CYBER875 can fully access more than 16 banks of ESM\n",
+                       startupFile, config);
             }
         break;
 
     default:
         if (modelType == ModelCyber865)
             {
-            fprintf(stderr, "(init   ) file '%s' section [%s]: Entry 'esmbanks' invalid - correct values are 0, 1, 2, 4, 8, 16, 32, 64 or 128\n",
-                startupFile, config);
+            logDtError(LogErrorLocation, "file '%s' section [%s]: Entry 'esmbanks' invalid - correct values are 0, 1, 2, 4, 8, 16, 32, 64 or 128\n",
+                       startupFile, config);
             }
         else
             {
-            fprintf(stderr, "(init   ) file '%s' section [%s]: Entry 'esmbanks' invalid - correct values are 0, 1, 2, 4, 8 or 16\n", startupFile, config);
+            logDtError(LogErrorLocation, "file '%s' section [%s]: Entry 'esmbanks' invalid - correct values are 0, 1, 2, 4, 8 or 16\n", startupFile, config);
             }
         exit(1);
         }
 
     if ((ecsBanks != 0) && (esmBanks != 0))
         {
-        fprintf(stderr, "(init   ) file '%s' section [%s]: 'ecsbanks' and 'esmbanks' are mutually exclusive\n", startupFile, config);
+        logDtError(LogErrorLocation, "file '%s' section [%s]: 'ecsbanks' and 'esmbanks' are mutually exclusive\n", startupFile, config);
         exit(1);
         }
 
@@ -803,7 +803,7 @@ static void initCyber(char *config)
     initGetInteger("cpus", 1, &cpus);
     if ((cpus < 1) || (cpus > MaxCpus))
         {
-        fprintf(stderr, "(init   ) file '%s' section [%s]: Entry 'cpus' invalid - correct values are 1 or 2\n", startupFile, config);
+        logDtError(LogErrorLocation, "file '%s' section [%s]: Entry 'cpus' invalid - correct values are 1 or 2\n", startupFile, config);
         exit(1);
         }
     cpuCount = (int)cpus;
@@ -817,21 +817,21 @@ static void initCyber(char *config)
         struct stat s;
         if (stat(persistDir, &s) != 0)
             {
-            fprintf(stderr, "(init   ) file '%s' section [%s]: Entry 'persistDir' specifies non-existing directory '%s'\n",
-                startupFile, config, persistDir);
+            logDtError(LogErrorLocation, "file '%s' section [%s]: Entry 'persistDir' specifies non-existing directory '%s'\n",
+                       startupFile, config, persistDir);
             exit(1);
             }
 
         if ((s.st_mode & S_IFDIR) == 0)
             {
-            fprintf(stderr, "(init   ) file '%s' section [%s]: Entry 'persistDir' specifies '%s' which is not a directory\n",
-                startupFile, config, persistDir);
+            logDtError(LogErrorLocation, "file '%s' section [%s]: Entry 'persistDir' specifies '%s' which is not a directory\n",
+                       startupFile, config, persistDir);
             exit(1);
             }
         }
     else
         {
-        fprintf(stderr, "(init   ) file '%s' section [%s]: Entry 'persistDir' is missing\n", startupFile, config);
+        logDtError(LogErrorLocation, "file '%s' section [%s]: Entry 'persistDir' is missing\n", startupFile, config);
         exit(1);
         }
 
@@ -855,7 +855,7 @@ static void initCyber(char *config)
     (void)initGetOctal("pps", 012, &pps);
     if ((pps != 012) && (pps != 024))
         {
-        fprintf(stderr, "(init   ) file '%s' section [%s]: Entry 'pps' invalid - supported values are 012 or 024\n", startupFile, config);
+        logDtError(LogErrorLocation, "file '%s' section [%s]: Entry 'pps' invalid - supported values are 012 or 024\n", startupFile, config);
         exit(1);
         }
 
@@ -880,7 +880,7 @@ static void initCyber(char *config)
     */
     if (!initGetString("deadstart", "", deadstart, sizeof(deadstart)))
         {
-        fprintf(stderr, "(init   ) file '%s' section [%s] Required entry 'deadstart' is missing\n", startupFile, config);
+        logDtError(LogErrorLocation, "file '%s' section [%s] Required entry 'deadstart' is missing\n", startupFile, config);
         exit(1);
         }
 
@@ -950,7 +950,7 @@ static void initCyber(char *config)
     */
     if (!initGetString("equipment", "", equipment, sizeof(equipment)))
         {
-        fprintf(stderr, "(init   ) file '%s' section [%s]: Required entry 'equipment' is missing\n", startupFile, config);
+        logDtError(LogErrorLocation, "file '%s' section [%s]: Required entry 'equipment' is missing\n", startupFile, config);
         exit(1);
         }
 
@@ -970,8 +970,8 @@ static void initCyber(char *config)
     initGetString("ipaddress", "0.0.0.0", ipAddress, 16);
     if (initParseIpAddress((strcmp(ipAddress, "0.0.0.0") == 0)? "127.0.0.1" : ipAddress, &npuNetHostIP, NULL) == FALSE)
         {
-        fprintf(stderr, "(init   ) file '%s' section [%s]: Invalid 'ipAddress' value %s - correct values are IPv4 addresses\n",
-                startupFile, config, ipAddress);
+        logDtError(LogErrorLocation, "file '%s' section [%s]: Invalid 'ipAddress' value %s - correct values are IPv4 addresses\n",
+                   startupFile, config, ipAddress);
         exit(1);
         }
     fprintf(stdout, "(init   ) IP address is '%s'\n", ipAddress);
@@ -1001,8 +1001,8 @@ static void initCyber(char *config)
             }
         if (strlen(dummy) > 16)
             {
-            fprintf(stderr, "(init   ) file '%s' section [%s]: Invalid 'networkInterface' value %s\n",
-                    startupFile, config, dummy);
+            logDtError(LogErrorLocation, "file '%s' section [%s]: Invalid 'networkInterface' value %s\n",
+                       startupFile, config, dummy);
             exit(1);
             }
         strcpy(networkInterface, dummy);
@@ -1016,7 +1016,7 @@ static void initCyber(char *config)
             }
         else
             {
-            fprintf(stderr, "(helper ) Failed to start \"%s\", rc=%d'\n", networkInterfaceMgr, rc);
+            logDtError(LogErrorLocation, "Failed to start \"%s\", rc=%d'\n", networkInterfaceMgr, rc);
             exit(1);
             }
         }
@@ -1054,7 +1054,7 @@ static void initCyber(char *config)
              && (strcasecmp(dummy, "false") != 0)
              && (strcasecmp(dummy, "0") != 0))
         {
-        fprintf(stderr, "(init   ) file '%s' section [%s]: Invalid value for 'idle' - must be one of 'on' or 'off'\n", startupFile, config);
+        logDtError(LogErrorLocation, "file '%s' section [%s]: Invalid value for 'idle' - must be one of 'on' or 'off'\n", startupFile, config);
         exit(1);
         }
 #if defined(_WIN32)
@@ -1111,8 +1111,8 @@ static void initCyber(char *config)
         }
     else
         {
-        fprintf(stderr, "(init   ) file '%s' section [%s]: WARNING: Unrecognized operating system type: '%s'\n",
-            startupFile, config, osType);
+        logDtError(LogErrorLocation, "file '%s' section [%s]: WARNING: Unrecognized operating system type: '%s'\n",
+                   startupFile, config, osType);
         }
 
     fprintf(stdout, "(init   ) Operating system type is '%s'.\n", osType);
@@ -1428,7 +1428,7 @@ static void initNpuConnections(void)
      */
     if (!initOpenSection(npuConnections))
         {
-        fprintf(stderr, "(init   ) Required section [%s] not found in '%s'\n", npuConnections, startupFile);
+        logDtError(LogErrorLocation, "Required section [%s] not found in '%s'\n", npuConnections, startupFile);
         exit(1);
         }
 
@@ -1452,17 +1452,17 @@ static void initNpuConnections(void)
                     if (strcasecmp(curVal->valName, token) == 0)
                         {
                         goodToken = TRUE;
-                        fprintf(stderr, "(init   ) file '%s' section [%s] line %2d: %-12s %s\n",
-                                startupFile, npuConnections, lineNo, token == NULL ? "NULL" : token, curVal->valStatus);
+                        logDtError(LogErrorLocation, "file '%s' section [%s] line %2d: %-12s %s\n",
+                                   startupFile, npuConnections, lineNo, token == NULL ? "NULL" : token, curVal->valStatus);
                         break;
                         }
                     }
                 }
             if (!goodToken)
                 {
-                fprintf(stderr, "(init   ) file '%s' section [%s] line %2d: invalid or deprecated configuration keyword %-12s %s\n",
-                        startupFile, npuConnections, lineNo, token == NULL ? "NULL" : token,
-                        curVal->valStatus == NULL ? "Invalid" : curVal->valStatus);
+                logDtError(LogErrorLocation, "file '%s' section [%s] line %2d: invalid or deprecated configuration keyword %-12s %s\n",
+                           startupFile, npuConnections, lineNo, token == NULL ? "NULL" : token,
+                           curVal->valStatus == NULL ? "Invalid" : curVal->valStatus);
                 numErrors++;
                 }
             }
@@ -1470,8 +1470,8 @@ static void initNpuConnections(void)
 
     if (numErrors > 0)
         {
-        fprintf(stderr, "(init   ) Correct the %d error(s) in section '[%s]' of '%s' and restart.\n",
-                numErrors, npuConnections, startupFile);
+        logDtError(LogErrorLocation, "Correct the %d error(s) in section '[%s]' of '%s' and restart.\n",
+                   numErrors, npuConnections, startupFile);
         exit(1);
         }
 
@@ -1480,7 +1480,7 @@ static void initNpuConnections(void)
 
     if (!initOpenSection(npuConnections))
         {
-        fprintf(stderr, "(init   ) Section [%s] not found in '%s'\n", npuConnections, startupFile);
+        logDtError(LogErrorLocation, "Section [%s] not found in '%s'\n", npuConnections, startupFile);
         exit(1);
         }
 
@@ -1489,7 +1489,7 @@ static void initNpuConnections(void)
     */
     (void)initGetString("hostID", "CYBER", npuNetHostID, HostIdSize);
     initToUpperCase(npuNetHostID);
-    fprintf(stderr, "(init   ) Network host ID is '%s'\n", npuNetHostID);
+    logDtError(LogErrorLocation, "Network host ID is '%s'\n", npuNetHostID);
 
     /*
     **  Get optional coupler node number. If not specified, use default value of 1.
@@ -1497,12 +1497,12 @@ static void initNpuConnections(void)
     initGetInteger("couplerNode", 1, &val);
     if ((val < 0) || (val > 255))
         {
-        fprintf(stderr, "(init   ) file '%s' section [%s]: Invalid 'couplerNode' value %ld - correct values are 1..255\n",
-                startupFile, npuConnections, val);
+        logDtError(LogErrorLocation, "file '%s' section [%s]: Invalid 'couplerNode' value %ld - correct values are 1..255\n",
+                   startupFile, npuConnections, val);
         exit(1);
         }
     npuSvmCouplerNode = (u8)val;
-    fprintf(stderr, "(init   ) Host coupler node value is %d\n", npuSvmCouplerNode);
+    logDtError(LogErrorLocation, "Host coupler node value is %d\n", npuSvmCouplerNode);
 
     /*
     **  Get optional NPU node number. If not specified, use default value of 2.
@@ -1510,12 +1510,12 @@ static void initNpuConnections(void)
     initGetInteger("npuNode", 2, &val);
     if ((val < 1) || (val > 255))
         {
-        fprintf(stderr, "(init   ) file '%s' section [%s]: Invalid 'npuNode' value %ld - correct values are 1..255\n",
-                startupFile, npuConnections, val);
+        logDtError(LogErrorLocation, "file '%s' section [%s]: Invalid 'npuNode' value %ld - correct values are 1..255\n",
+                   startupFile, npuConnections, val);
         exit(1);
         }
     npuSvmNpuNode = (u8)val;
-    fprintf(stderr, "(init   ) NPU node value is %d\n", npuSvmNpuNode);
+    logDtError(LogErrorLocation, "NPU node value is %d\n", npuSvmNpuNode);
 
     /*
     **  Get optional CDCNet node number. If not specified, use default value of 255.
@@ -1523,12 +1523,12 @@ static void initNpuConnections(void)
     initGetInteger("cdcnetNode", 255, &val);
     if ((val < 1) || (val > 255))
         {
-        fprintf(stderr, "(init   ) file '%s' section [%s]: Invalid 'cdcnetNode' value %ld - correct values are 1..255\n",
-                startupFile, npuConnections, val);
+        logDtError(LogErrorLocation, "file '%s' section [%s]: Invalid 'cdcnetNode' value %ld - correct values are 1..255\n",
+                   startupFile, npuConnections, val);
         exit(1);
         }
     cdcnetNode = (u8)val;
-    fprintf(stderr, "(init   ) CDCNet node value is %d\n", cdcnetNode);
+    logDtError(LogErrorLocation, "CDCNet node value is %d\n", cdcnetNode);
 
     /*
     **  Get optional privileged TCP and UDP port offsets for CDCNet TCP/IP passive connections. If not specified,
@@ -1537,22 +1537,22 @@ static void initNpuConnections(void)
     initGetInteger("cdcnetPrivilegedTcpPortOffset", 6600, &val);
     if ((val < 0) || (val > 64000))
         {
-        fprintf(stderr, "(init   ) file '%s' section [%s]: Invalid 'cdcnetPrivilegedTcpPortOffset' value %ld - correct values are 0..64000\n",
-                startupFile, npuConnections, val);
+        logDtError(LogErrorLocation, "file '%s' section [%s]: Invalid 'cdcnetPrivilegedTcpPortOffset' value %ld - correct values are 0..64000\n",
+                   startupFile, npuConnections, val);
         exit(1);
         }
     cdcnetPrivilegedTcpPortOffset = (u16)val;
-    fprintf(stderr, "(init   ) TCP privileged port offset is %d\n", cdcnetPrivilegedTcpPortOffset);
+    logDtError(LogErrorLocation, "TCP privileged port offset is %d\n", cdcnetPrivilegedTcpPortOffset);
 
     initGetInteger("cdcnetPrivilegedUdpPortOffset", 6600, &val);
     if ((val < 0) || (val > 64000))
         {
-        fprintf(stderr, "(init   ) file '%s' section [%s]: Invalid 'cdcnetPrivilegedUdpPortOffset' value %ld - correct values are 0..64000\n",
-                startupFile, npuConnections, val);
+        logDtError(LogErrorLocation, "file '%s' section [%s]: Invalid 'cdcnetPrivilegedUdpPortOffset' value %ld - correct values are 0..64000\n",
+                   startupFile, npuConnections, val);
         exit(1);
         }
     cdcnetPrivilegedUdpPortOffset = (u16)val;
-    fprintf(stderr, "(init   ) UDP privileged port offset is %d\n", cdcnetPrivilegedUdpPortOffset);
+    logDtError(LogErrorLocation, "UDP privileged port offset is %d\n", cdcnetPrivilegedUdpPortOffset);
 
     /*
     **  Get optional threshold value of network buffer backlog indicating that the NPU/MDI
@@ -1560,14 +1560,14 @@ static void initNpuConnections(void)
     */
     initGetInteger("idleNetBufs", 4, &val);
     idleNetBufs = (u32)val;
-    fprintf(stderr, "(init   ) Idle network buffer threshold is %d\n", idleNetBufs);
+    logDtError(LogErrorLocation, "Idle network buffer threshold is %d\n", idleNetBufs);
 
     /*
     **  Process all equipment entries.
     */
     if (!initOpenSection(npuConnections))
         {
-        fprintf(stderr, "(init   ) Section [%s] not found in '%s'\n", npuConnections, startupFile);
+        logDtError(LogErrorLocation, "Section [%s] not found in '%s'\n", npuConnections, startupFile);
         exit(1);
         }
 
@@ -1627,8 +1627,8 @@ static void initNpuConnections(void)
             */
             connType = initParseTerminalDefn(line, startupFile, npuConnections, lineNo,
                                              &tcpPort, &claPort, &numConns, &remainder);
-            fprintf(stderr, "(init   ) [%s] line %2d: %6s TCP port %5d CLA port 0x%02x port count %3d",
-                npuConnections, lineNo, connTypeNames[connType], tcpPort, claPort, numConns);
+            logDtError(LogErrorLocation, "[%s] line %2d: %6s TCP port %5d CLA port 0x%02x port count %3d",
+                       npuConnections, lineNo, connTypeNames[connType], tcpPort, claPort, numConns);
 
             rc = npuNetRegisterConnType(tcpPort, claPort, numConns, connType, &ncbp);
             switch (rc)
@@ -1638,11 +1638,11 @@ static void initNpuConnections(void)
                 break;
 
             case NpuNetRegOvfl:
-                fprintf(stderr, "\n(init   )   Too many terminal and trunk definitions (max of %d)\n", MaxTermDefs);
+                logDtError(LogErrorLocation, "\n(init   )   Too many terminal and trunk definitions (max of %d)\n", MaxTermDefs);
                 exit(1);
 
             case NpuNetRegDupTcp:
-                fprintf(stderr, "\n(init   )   Duplicate TCP port %d\n", tcpPort);
+                logDtError(LogErrorLocation, "\n(init   )   Duplicate TCP port %d\n", tcpPort);
                 exit(1);
 
             case NpuNetRegDupCla:
@@ -1654,7 +1654,7 @@ static void initNpuConnections(void)
                 exit(1);
 
             default:
-                fprintf(stderr, "\n(init   )   Failed to register terminals, unexpected error %d\n", rc);
+                logDtError(LogErrorLocation, "\n(init   )   Failed to register terminals, unexpected error %d\n", rc);
                 exit(1);
                 }
 
@@ -1680,7 +1680,7 @@ static void initNpuConnections(void)
                         }
                     else
                         {
-                        fprintf(stderr, "\n(init   )   Unrecognized keyword '%s'\n", token);
+                        logDtError(LogErrorLocation, "\n(init   )   Unrecognized keyword '%s'\n", token);
                         exit(1);
                         }
                     while (numConns-- > 0)
@@ -1704,21 +1704,21 @@ static void initNpuConnections(void)
                         val = strtol(token + 1, NULL, 10);
                         if ((val < MinBlockSize) || (val > MaxBlockSize))
                             {
-                            fprintf(stderr, "\n(init   )   Invalid block size %ld - correct block sizes are %d .. %d\n",
-                                val, MinBlockSize, MaxBlockSize);
+                            logDtError(LogErrorLocation, "\n(init   )   Invalid block size %ld - correct block sizes are %d .. %d\n",
+                                       val, MinBlockSize, MaxBlockSize);
                             exit(1);
                             }
                         blockSize = (int)val;
                         }
                     else
                         {
-                        fprintf(stderr, "\n(init   )   Invalid block size specification '%s'\n", token);
+                        logDtError(LogErrorLocation, "\n(init   )   Invalid block size specification '%s'\n", token);
                         exit(1);
                         }
                     }
                 pcbp = npuNetFindPcb(claPort);
                 pcbp->controls.hasp.blockSize = blockSize;
-                fprintf(stderr, ", block size %4d", blockSize);
+                logDtError(LogErrorLocation, ", block size %4d", blockSize);
                 break;
 
             case ConnTypeRevHasp:
@@ -1734,12 +1734,12 @@ static void initNpuConnections(void)
                 destHostAddr = token;
                 if (initParseIpAddress(destHostAddr, &destHostIP, &destHostPort) == FALSE)
                     {
-                    fprintf(stderr, "\n(init   )   Invalid Reverse HASP address '%s'\n", destHostAddr);
+                    logDtError(LogErrorLocation, "\n(init   )   Invalid Reverse HASP address '%s'\n", destHostAddr);
                     exit(1);
                     }
                 if (destHostPort == 0)
                     {
-                    fprintf(stderr, "\n(init   )   Missing port number on Reverse HASP address '%s'\n", destHostAddr);
+                    logDtError(LogErrorLocation, "\n(init   )   Missing port number on Reverse HASP address '%s'\n", destHostAddr);
                     exit(1);
                     }
                 destHostName = destHostAddr;
@@ -1752,20 +1752,20 @@ static void initNpuConnections(void)
                         val = strtol(token + 1, NULL, 10);
                         if ((val < MinBlockSize) || (val > MaxBlockSize))
                             {
-                            fprintf(stderr, "\n(init   )   Invalid block size %ld - correct block sizes are %d .. %d\n",
-                                val, MinBlockSize, MaxBlockSize);
+                            logDtError(LogErrorLocation, "\n(init   )   Invalid block size %ld - correct block sizes are %d .. %d\n",
+                                       val, MinBlockSize, MaxBlockSize);
                             exit(1);
                             }
                         blockSize = (int)val;
                         }
                     else
                         {
-                        fprintf(stderr, "\n(init   )   Invalid Reverse HASP block size specification '%s'\n", token);
+                        logDtError(LogErrorLocation, "\n(init   )   Invalid Reverse HASP block size specification '%s'\n", token);
                         exit(1);
                         }
                     }
-                fprintf(stderr, ", block size %4d", blockSize);
-                fprintf(stderr, ", destination host %s", destHostName);
+                logDtError(LogErrorLocation, ", block size %4d", blockSize);
+                logDtError(LogErrorLocation, ", destination host %s", destHostName);
                 break;
 
             case ConnTypeNje:
@@ -1787,7 +1787,7 @@ static void initNpuConnections(void)
                 destHostAddr = token;
                 if (initParseIpAddress(destHostAddr, &destHostIP, &destHostPort) == FALSE)
                     {
-                    fprintf(stderr, "\n(init   )   Invalid remote NJE node address %s\n", destHostAddr);
+                    logDtError(LogErrorLocation, "\n(init   )   Invalid remote NJE node address %s\n", destHostAddr);
                     exit(1);
                     }
                 token = strtok(NULL, ", ");
@@ -1809,8 +1809,8 @@ static void initNpuConnections(void)
                         val = strtol(token + 1, NULL, 10);
                         if (val < MinNjeBlockSize)
                             {
-                            fprintf(stderr, "\n(init   )   Invalid block size %ld - correct block size is at least %d\n",
-                                    val, MinNjeBlockSize);
+                            logDtError(LogErrorLocation, "\n(init   )   Invalid block size %ld - correct block size is at least %d\n",
+                                       val, MinNjeBlockSize);
                             exit(1);
                             }
                         blockSize = (int)val;
@@ -1820,25 +1820,25 @@ static void initNpuConnections(void)
                         pingInterval = strtol(token + 1, NULL, 10);
                         if (pingInterval < 0)
                             {
-                            fprintf(stderr, "\n(init   )   Invalid ping interval %ld\n", pingInterval);
+                            logDtError(LogErrorLocation, "\n(init   )   Invalid ping interval %ld\n", pingInterval);
                             exit(1);
                             }
                         }
                     else if (initParseIpAddress(token, &localHostIP, NULL) == FALSE)
                         {
-                        fprintf(stderr, "\n(init   )   Invalid local NJE node address %s\n", token);
+                        logDtError(LogErrorLocation, "\n(init   )   Invalid local NJE node address %s\n", token);
                         exit(1);
                         }
                     token = strtok(NULL, ", ");
                     }
-                fprintf(stderr, ", block size %4d", blockSize);
-                fprintf(stderr, ", destination host %s/%s", destHostName, destHostAddr);
-                fprintf(stderr, ", source address %d.%d.%d.%d",
-                    (localHostIP >> 24) & 0xff,
-                    (localHostIP >> 16) & 0xff,
-                    (localHostIP >> 8) & 0xff,
-                     localHostIP & 0xff);
-                fprintf(stderr, ", ping interval %ld", pingInterval);
+                logDtError(LogErrorLocation, ", block size %4d", blockSize);
+                logDtError(LogErrorLocation, ", destination host %s/%s", destHostName, destHostAddr);
+                logDtError(LogErrorLocation, ", source address %d.%d.%d.%d",
+                           (localHostIP >> 24) & 0xff,
+                           (localHostIP >> 16) & 0xff,
+                           (localHostIP >> 8) & 0xff,
+                           localHostIP & 0xff);
+                logDtError(LogErrorLocation, ", ping interval %ld", pingInterval);
                 break;
 
             case ConnTypeTrunk:
@@ -1859,7 +1859,7 @@ static void initNpuConnections(void)
                 destHostAddr = token;
                 if (initParseIpAddress(destHostAddr, &destHostIP, &destHostPort) == FALSE)
                     {
-                    fprintf(stderr, "\n(init   )   Invalid remote host IP address %s\n", destHostAddr);
+                    logDtError(LogErrorLocation, "\n(init   )   Invalid remote host IP address %s\n", destHostAddr);
                     exit(1);
                     }
                 token = strtok(NULL, ", ");
@@ -1881,12 +1881,12 @@ static void initNpuConnections(void)
 
                 if ((val < 1) || (val > 255))
                     {
-                    fprintf(stderr, "\n(init   )   Invalid coupler node number %ld\n", val);
+                    logDtError(LogErrorLocation, "\n(init   )   Invalid coupler node number %ld\n", val);
                     exit(1);
                     }
                 destNode = (u8)val;
-                fprintf(stderr, ", coupler node %d", destNode);
-                fprintf(stderr, ", destination host %s/%s", destHostName, destHostAddr);
+                logDtError(LogErrorLocation, ", coupler node %d", destNode);
+                logDtError(LogErrorLocation, ", destination host %s/%s", destHostName, destHostAddr);
                 break;
                 }
 
@@ -1965,7 +1965,7 @@ static void initEquipment(void)
 
     if (!initOpenSection(equipment))
         {
-        fprintf(stderr, "(init   ) Required section [%s] not found in '%s'\n", equipment, startupFile);
+        logDtError(LogErrorLocation, "Required section [%s] not found in '%s'\n", equipment, startupFile);
         exit(1);
         }
 
@@ -1988,28 +1988,28 @@ static void initEquipment(void)
             {
             if (initLookupDeviceType(token) >= 0)
                 {
-                fprintf(stderr, "(init   ) file '%s' section [%s] line %2d: %-10s Valid\n",
-                        startupFile, equipment, lineNo, token == NULL ? "NULL" : token);
+                logDtError(LogErrorLocation, "file '%s' section [%s] line %2d: %-10s Valid\n",
+                           startupFile, equipment, lineNo, token == NULL ? "NULL" : token);
                 }
             else
                 {
-                fprintf(stderr, "(init   ) file '%s' section [%s] line %2d: invalid device type '%s'\n",
-                        startupFile, equipment, lineNo, token == NULL ? "NULL" : token);
+                logDtError(LogErrorLocation, "file '%s' section [%s] line %2d: invalid device type '%s'\n",
+                           startupFile, equipment, lineNo, token == NULL ? "NULL" : token);
                 numErrors++;
                 }
             }
         else
             {
-            fprintf(stderr, "(init   ) file '%s' section [%s] line %2d: invalid device definition '%s'\n",
-                startupFile, equipment, lineNo, token == NULL ? "NULL" : line);
+            logDtError(LogErrorLocation, "file '%s' section [%s] line %2d: invalid device definition '%s'\n",
+                       startupFile, equipment, lineNo, token == NULL ? "NULL" : line);
             numErrors++;
             }
         }
 
     if (numErrors > 0)
         {
-        fprintf(stderr, "(init   ) Correct the %d error(s) in section '[%s]' of '%s' and restart.\n",
-                numErrors, equipment, startupFile);
+        logDtError(LogErrorLocation, "Correct the %d error(s) in section '[%s]' of '%s' and restart.\n",
+                   numErrors, equipment, startupFile);
         exit(1);
         }
 
@@ -2068,15 +2068,15 @@ static int initParseEquipmentDefn(char *defn, char *file, char *section, int lin
         deviceIndex = initLookupDeviceType(token);
         if (deviceIndex < 0)
             {
-            fprintf(stderr, "(init   ) file '%s' section [%s] line %2d: invalid device type '%s'\n",
-                    file, section, lineNo, token == NULL ? "NULL" : token);
+            logDtError(LogErrorLocation, "file '%s' section [%s] line %2d: invalid device type '%s'\n",
+                       file, section, lineNo, token == NULL ? "NULL" : token);
             exit(1);
             }
         }
     else
         {
-        fprintf(stderr, "(init   ) file '%s' section [%s] line %2d: invalid device definition '%s'\n",
-            file, section, lineNo, token == NULL ? "NULL" : defn);
+        logDtError(LogErrorLocation, "file '%s' section [%s] line %2d: invalid device definition '%s'\n",
+                   file, section, lineNo, token == NULL ? "NULL" : defn);
         exit(1);
         }
 
@@ -2086,8 +2086,8 @@ static int initParseEquipmentDefn(char *defn, char *file, char *section, int lin
     token = strtok(NULL, ",");
     if ((token == NULL) || (strlen(token) != 1) || !isoctal(token[0]))
         {
-        fprintf(stderr, "(init   ) file '%s' section [%s] line %d: invalid equipment number %s\n",
-                file, section, lineNo, token == NULL ? "NULL" : token);
+        logDtError(LogErrorLocation, "file '%s' section [%s] line %d: invalid equipment number %s\n",
+                   file, section, lineNo, token == NULL ? "NULL" : token);
         exit(1);
         }
 
@@ -2099,8 +2099,8 @@ static int initParseEquipmentDefn(char *defn, char *file, char *section, int lin
     token = strtok(NULL, ",");
     if ((token == NULL) || !isoctal(token[0]))
         {
-        fprintf(stderr, "(init   ) file '%s' section [%s] line %d: invalid unit number %s\n",
-                file, section, lineNo, token == NULL ? "NULL" : token);
+        logDtError(LogErrorLocation, "file '%s' section [%s] line %d: invalid unit number %s\n",
+                   file, section, lineNo, token == NULL ? "NULL" : token);
         exit(1);
         }
 
@@ -2112,16 +2112,16 @@ static int initParseEquipmentDefn(char *defn, char *file, char *section, int lin
     token = strtok(NULL, ", ");
     if ((token == NULL) || (strlen(token) != 2) || !isoctal(token[0]) || !isoctal(token[1]))
         {
-        fprintf(stderr, "(init   ) file '%s' section [%s] line %d: invalid channel number %s\n",
-                file, section, lineNo, token == NULL ? "NULL" : token);
+        logDtError(LogErrorLocation, "file '%s' section [%s] line %d: invalid channel number %s\n",
+                   file, section, lineNo, token == NULL ? "NULL" : token);
         exit(1);
         }
 
     *channelNo = (u8)strtol(token, NULL, 8);
     if ((*channelNo < 0) || (*channelNo >= chCount))
         {
-        fprintf(stderr, "(init   ) file '%s' section [%s] line %d: invalid channel number %s\n",
-                file, section, lineNo, token == NULL ? "NULL" : token);
+        logDtError(LogErrorLocation, "file '%s' section [%s] line %d: invalid channel number %s\n",
+                   file, section, lineNo, token == NULL ? "NULL" : token);
         exit(1);
         }
 
@@ -2162,24 +2162,24 @@ static int initParseTerminalDefn(char *defn, char *file, char *section, int line
     token = strtok(defn, ",=");
     if ((token == NULL) || (strcasecmp(token, "terminals") != 0))
         {
-        fprintf(stderr, "(init   ) file '%s' section [%s] line %2d: Invalid terminal definition '%s'\n",
-            file, section, lineNo, token == NULL ? "NULL" : token);
+        logDtError(LogErrorLocation, "file '%s' section [%s] line %2d: Invalid terminal definition '%s'\n",
+                   file, section, lineNo, token == NULL ? "NULL" : token);
         exit(1);
         }
 
     token = strtok(NULL, ",");
     if ((token == NULL) || !isdigit(token[0]))
         {
-        fprintf(stderr, "(init   ) file '%s' section [%s] line %2d: Invalid TCP port number %s\n",
-            file, section, lineNo, token == NULL ? "NULL" : token);
+        logDtError(LogErrorLocation, "file '%s' section [%s] line %2d: Invalid TCP port number %s\n",
+                   file, section, lineNo, token == NULL ? "NULL" : token);
         exit(1);
         }
 
     val = strtol(token, NULL, 10);
     if (val > 65535)
         {
-        fprintf(stderr, "(init   ) file '%s' section [%s] line %2d: Invalid TCP port number %ld\n",
-            file, section, lineNo, val);
+        logDtError(LogErrorLocation, "file '%s' section [%s] line %2d: Invalid TCP port number %ld\n",
+                   file, section, lineNo, val);
         exit(1);
         }
     *tcpPort = (u16)val;
@@ -2190,17 +2190,17 @@ static int initParseTerminalDefn(char *defn, char *file, char *section, int line
     token = strtok(NULL, ",");
     if ((token == NULL) || !isxdigit(token[0]))
         {
-        fprintf(stderr, "(init   ) file '%s' section [%s] line %2d: Invalid CLA port number %s\n",
-            file, section, lineNo, token == NULL ? "NULL" : token);
+        logDtError(LogErrorLocation, "file '%s' section [%s] line %2d: Invalid CLA port number %s\n",
+                   file, section, lineNo, token == NULL ? "NULL" : token);
         exit(1);
         }
 
     val = strtol(token, NULL, 16);
     if ((val < 1) || (val > 255))
         {
-        fprintf(stderr, "(init   ) file '%s' section [%s] line %2d: Invalid CLA port number %ld\n",
-            file, section, lineNo, val);
-        fprintf(stderr, "(init   ) CLA port numbers must be between 0x01 and 0xFF, expressed in hexadecimal\n");
+        logDtError(LogErrorLocation, "file '%s' section [%s] line %2d: Invalid CLA port number %ld\n",
+                   file, section, lineNo, val);
+        logDtError(LogErrorLocation, "CLA port numbers must be between 0x01 and 0xFF, expressed in hexadecimal\n");
         exit(1);
         }
     *claPort = (u8)val;
@@ -2211,17 +2211,17 @@ static int initParseTerminalDefn(char *defn, char *file, char *section, int line
     token = strtok(NULL, ",");
     if ((token == NULL) || !isdigit(token[0]))
         {
-        fprintf(stderr, "(init   ) file '%s' section [%s] line %2d: Invalid number of connections %s\n",
-            file, section, lineNo, token == NULL ? "NULL" : token);
+        logDtError(LogErrorLocation, "file '%s' section [%s] line %2d: Invalid number of connections %s\n",
+                   file, section, lineNo, token == NULL ? "NULL" : token);
         exit(1);
         }
 
     val = strtol(token, NULL, 10);
-    if ((val < 1) || (val > 100))
+    if ((val < 1) || (val > 255))
         {
-        fprintf(stderr, "(init   ) file '%s' section [%s] line %2d: Invalid number of connections %ld\n",
-            file, section, lineNo, val);
-        fprintf(stderr, "(init   ) Connection count must be between 0 and 100\n");
+        logDtError(LogErrorLocation, "file '%s' section [%s] line %2d: Invalid number of connections %ld\n",
+                   file, section, lineNo, val);
+        logDtError(LogErrorLocation, "Connection count must be between 1 and 255\n");
         exit(1);
         }
     *claPortCount = (u8)val;
@@ -2232,16 +2232,16 @@ static int initParseTerminalDefn(char *defn, char *file, char *section, int line
     token = strtok(NULL, ", ");
     if (token == NULL)
         {
-        fprintf(stderr, "(init   ) file '%s' section [%s] line %2d: Invalid NPU connection type %s\n",
-            file, section, lineNo, token == NULL ? "NULL" : token);
+        logDtError(LogErrorLocation, "file '%s' section [%s] line %2d: Invalid NPU connection type %s\n",
+                   file, section, lineNo, token == NULL ? "NULL" : token);
         exit(1);
         }
     connType = initLookupConnType(token);
     if (connType == -1)
         {
-        fprintf(stderr, "(init   ) file '%s' section [%s] line %2d: Invalid NPU connection type %s\n",
-            file, section, lineNo, token);
-        fprintf(stderr, "(init   ) NPU connection types must be one of: hasp, nje, pterm, raw, rhasp, rs232, telnet\n");
+        logDtError(LogErrorLocation, "file '%s' section [%s] line %2d: Invalid NPU connection type %s\n",
+                   file, section, lineNo, token);
+        logDtError(LogErrorLocation, "NPU connection types must be one of: hasp, nje, pterm, raw, rhasp, rs232, telnet\n");
         exit(1);
         }
 
@@ -2268,7 +2268,7 @@ static void initDeadstart(void)
 
     if (!initOpenSection(deadstart))
         {
-        fprintf(stderr, "(init   ) Required section [%s] not found in %s\n", deadstart, startupFile);
+        logDtError(LogErrorLocation, "Required section [%s] not found in %s\n", deadstart, startupFile);
         exit(1);
         }
 
@@ -2289,8 +2289,8 @@ static void initDeadstart(void)
             || !isoctal(token[0]) || !isoctal(token[1])
             || !isoctal(token[2]) || !isoctal(token[3]))
             {
-            fprintf(stderr, "(init   ) file '%s' section [%s] line %2d: invalid deadstart setting %s\n",
-                    startupFile, deadstart, lineNo, token == NULL ? "NULL" : token);
+            logDtError(LogErrorLocation, "file '%s' section [%s] line %2d: invalid deadstart setting %s\n",
+                       startupFile, deadstart, lineNo, token == NULL ? "NULL" : token);
             exit(1);
             }
 
@@ -2341,7 +2341,7 @@ static void initHelpers(void)
 
     if (initOpenHelpersSection() == -1)
         {
-        fprintf(stderr, "(init   ) Section [%s] not found in %s\n", helpers, startupFile);
+        logDtError(LogErrorLocation, "Section [%s] not found in %s\n", helpers, startupFile);
         exit(1);
         }
     }
@@ -2363,7 +2363,7 @@ static void initOperator(void)
 
     if (initOpenOperatorSection() == -1)
         {
-        fprintf(stderr, "(init   ) Section [%s] not found in %s\n", operator, startupFile);
+        logDtError(LogErrorLocation, "Section [%s] not found in %s\n", operator, startupFile);
         exit(1);
         }
     }
@@ -2722,7 +2722,7 @@ static void initReadStartupFile(FILE *fcb, char *fileName)
                 else if ((*cp == '\0') || isspace(*cp))
                     {
                     *cp = '\0';
-                    fprintf(stderr, "(init   ) Invalid section identifier starting with [\"%s\" in %s\n", sp, fileName);
+                    logDtError(LogErrorLocation, "Invalid section identifier starting with [\"%s\" in %s\n", sp, fileName);
                     exit(1);
                     }
                 else

--- a/lp1612.c
+++ b/lp1612.c
@@ -601,7 +601,7 @@ static FcStatus lp1612Func(PpWord funcCode)
         lp1612DebugData(lc);
 #endif
         switch (lc->renderingMode)
-        {
+            {
         default:
         case ModeCDC:
             lp1612PrintCDC(lc, fcb);
@@ -614,7 +614,7 @@ static FcStatus lp1612Func(PpWord funcCode)
         case ModeASCII:
             lp1612PrintASCII(lc, fcb);
             break;
-        }
+            }
         lc->linePos = 0;
         break;
 
@@ -891,7 +891,7 @@ static char *lp1612FeForPostPrint(LpContext *lc, PpWord func)
         {
     case ModeCDC:
         switch (func)
-        {
+            {
         default:
             return "";
 
@@ -902,7 +902,7 @@ static char *lp1612FeForPostPrint(LpContext *lc, PpWord func)
         case FcPrintFormat5:
         case FcPrintFormat6:
             return postPrintCdcEffectors[lc->postPrintFunc - FcPrintFormat1];
-        }
+            }
         break;
 
     case ModeANSI:
@@ -929,7 +929,7 @@ static char *lp1612FeForPrePrint(LpContext *lc, PpWord func)
     default:
     case ModeCDC:
         switch (func)
-        {
+            {
         default:
             return " ";
 
@@ -947,12 +947,12 @@ static char *lp1612FeForPrePrint(LpContext *lc, PpWord func)
 
         case FcPrintNoSpace:
             return "+";
-        }
+            }
         break;
 
     case ModeANSI:
         switch (func)
-        {
+            {
         default:
             return " ";
 
@@ -978,12 +978,12 @@ static char *lp1612FeForPrePrint(LpContext *lc, PpWord func)
         case FcPrintFormat5:
         case FcPrintFormat6:
             return prePrintAnsiEffectors[lc->postPrintFunc - FcPrintFormat1];
-        }
+            }
         break;
 
     case ModeASCII:
         switch (func)
-        {
+            {
         default:
             return "";
 
@@ -995,7 +995,7 @@ static char *lp1612FeForPrePrint(LpContext *lc, PpWord func)
 
         case FcPrintEject:
             return "\f";
-        }
+            }
         break;
         }
     }

--- a/lp1612.c
+++ b/lp1612.c
@@ -99,14 +99,14 @@
 /*
 **  Output rendering modes
 */
-#define ModeCDC                  0
-#define ModeANSI                 1
-#define ModeASCII                2
+#define ModeCDC                0
+#define ModeANSI               1
+#define ModeASCII              2
 
 /*
 **  Maximum number of characters per line
 */
-#define MaxLineSize              120
+#define MaxLineSize            120
 
 /*
 **  -----------------------
@@ -128,20 +128,20 @@ typedef struct lpContext
     /*
     **  Info for show_tape operator command.
     */
-    struct lpContext    *nextUnit;
-    u8                   channelNo;
-    u8                   eqNo;
-    u8                   unitNo;
+    struct lpContext *nextUnit;
+    u8               channelNo;
+    u8               eqNo;
+    u8               unitNo;
 
-    u8                   renderingMode;
-    PpWord               prePrintFunc;       //  last pre-print function (0 = no pre-print function specified)
-    PpWord               postPrintFunc;      //  last post-print function (0 = no post-print function specified)
-    bool                 doSuppress;         //  suppress next post-print spacing op
-    PpWord               line[MaxLineSize];  //  buffered line
-    u8                   linePos;            //  current line position
+    u8               renderingMode;
+    PpWord           prePrintFunc;           //  last pre-print function (0 = no pre-print function specified)
+    PpWord           postPrintFunc;          //  last post-print function (0 = no post-print function specified)
+    bool             doSuppress;             //  suppress next post-print spacing op
+    PpWord           line[MaxLineSize];      //  buffered line
+    u8               linePos;                //  current line position
 
-    char                 path[MaxFSPath];
-    char                 curFileName[MaxFSPath+128];
+    char             path[MaxFSPath];
+    char             curFileName[MaxFSPath + 128];
     } LpContext;
 
 /*
@@ -162,6 +162,7 @@ static void     lp1612PrintCDC(LpContext *lc, FILE *fcb);
 #if DEBUG
 static void lp1612DebugData(LpContext *lc);
 static char *lp1612Func2String(PpWord funcCode);
+
 #endif
 
 /*
@@ -179,29 +180,32 @@ static char *lp1612Func2String(PpWord funcCode);
 static LpContext *firstLp1612 = NULL;
 static LpContext *lastLp1612  = NULL;
 
-static char *prePrintAnsiEffectors[] = {
+static char *prePrintAnsiEffectors[] =
+    {
     " ", // print format 1
     "2", // print format 2
     "3", // print format 3
     "4", // print format 4
     "5", // print format 5
     "6", // print format 6
-};
+    };
 
-static char *postPrintCdcEffectors[] = {
+static char *postPrintCdcEffectors[] =
+    {
     " ", // print format 1
     "G", // print format 2
     "F", // print format 3
     "E", // print format 4
     "D", // print format 5
     "C", // print format 6
-};
+    };
 
-static char *renderingModes[] = {
+static char *renderingModes[] =
+    {
     "CDC",
     "ANSI",
     "ASCII"
-};
+    };
 
 #if DEBUG
 static FILE *lp1612Log = NULL;
@@ -244,13 +248,13 @@ void lp1612Init(u8 eqNo, u8 unitNo, u8 channelNo, char *deviceName)
 
     if (eqNo != 0)
         {
-        fprintf(stderr, "(lp1612 ) Invalid equipment number - LP1612 is hardwired to equipment number 0\n");
+        logDtError(LogErrorLocation, "Invalid equipment number - LP1612 is hardwired to equipment number 0\n");
         exit(1);
         }
 
     if (unitNo != 0)
         {
-        fprintf(stderr, "(lp1612 ) Invalid unit number - LP1612 is hardwired to unit number 0\n");
+        logDtError(LogErrorLocation, "Invalid unit number - LP1612 is hardwired to unit number 0\n");
         exit(1);
         }
 
@@ -264,7 +268,7 @@ void lp1612Init(u8 eqNo, u8 unitNo, u8 channelNo, char *deviceName)
     lc = (LpContext *)calloc(1, sizeof(LpContext));
     if (lc == NULL)
         {
-        fprintf(stderr, "(lp1612 ) Failed to allocate LP1612 context block\n");
+        logDtError(LogErrorLocation, "Failed to allocate LP1612 context block\n");
         exit(1);
         }
 
@@ -301,7 +305,7 @@ void lp1612Init(u8 eqNo, u8 unitNo, u8 channelNo, char *deviceName)
             }
         else
             {
-            fprintf(stderr, "(lp1612 ) Unrecognized output rendering mode '%s'\n", deviceMode);
+            logDtError(LogErrorLocation, "Unrecognized output rendering mode '%s'\n", deviceMode);
             exit(1);
             }
         }
@@ -337,7 +341,7 @@ void lp1612Init(u8 eqNo, u8 unitNo, u8 channelNo, char *deviceName)
 
     if (dp->fcb[0] == NULL)
         {
-        fprintf(stderr, "(lp1612 ) Failed to open %s\n", lc->curFileName);
+        logDtError(LogErrorLocation, "Failed to open %s\n", lc->curFileName);
         exit(1);
         }
 
@@ -373,7 +377,7 @@ void lp1612Init(u8 eqNo, u8 unitNo, u8 channelNo, char *deviceName)
 void lp1612ShowStatus()
     {
     LpContext *lc;
-    char      outBuf[MaxFSPath+128];
+    char      outBuf[MaxFSPath + 128];
 
     for (lc = firstLp1612; lc != NULL; lc = lc->nextUnit)
         {
@@ -401,11 +405,11 @@ void lp1612RemovePaper(char *params)
     time_t    currentTime;
     DevSlot   *dp;
     int       equipmentNo;
-    char      fNameNew[MaxFSPath+128];
+    char      fNameNew[MaxFSPath + 128];
     int       iSuffix;
     LpContext *lc;
     int       numParam;
-    char      outBuf[MaxFSPath*2+300];
+    char      outBuf[MaxFSPath * 2 + 300];
     bool      renameOK;
     struct tm t;
 
@@ -455,9 +459,9 @@ void lp1612RemovePaper(char *params)
     //          and the file fails to be properly re-opened.
     if (dp->fcb[0] == NULL)
         {
-        fprintf(stderr, "(lp1612 ) lp1612RemovePaper: FCB is null on channel %o equipment %o\n",
-                dp->channel->id,
-                dp->eqNo);
+        logDtError(LogErrorLocation, "RemovePaper: FCB is null on channel %o equipment %o\n",
+                   dp->channel->id,
+                   dp->eqNo);
         //  proceed to attempt to open a new FCB
         }
     else
@@ -515,11 +519,11 @@ void lp1612RemovePaper(char *params)
                     break;
                     }
 
-                fprintf(stderr, "(lp1612 ) Rename Failure '%s' to '%s' - (%s). Retrying (%d)...\n",
-                        lc->curFileName,
-                        fNameNew,
-                        strerror(errno),
-                        iSuffix);
+                logDtError(LogErrorLocation, "Rename Failure '%s' to '%s' - (%s). Retrying (%d)...\n",
+                           lc->curFileName,
+                           fNameNew,
+                           strerror(errno),
+                           iSuffix);
                 }
             }
         }
@@ -534,7 +538,7 @@ void lp1612RemovePaper(char *params)
     */
     if (dp->fcb[0] == NULL)
         {
-        fprintf(stderr, "(lp1612 ) Failed to open %s\n", lc->curFileName);
+        logDtError(LogErrorLocation, "Failed to open %s\n", lc->curFileName);
 
         return;
         }
@@ -557,8 +561,8 @@ void lp1612RemovePaper(char *params)
 **------------------------------------------------------------------------*/
 static FcStatus lp1612Func(PpWord funcCode)
     {
-    LpContext *lc = (LpContext *)activeDevice->context[0];
-    FILE *fcb         = activeDevice->fcb[0];
+    LpContext *lc  = (LpContext *)activeDevice->context[0];
+    FILE      *fcb = activeDevice->fcb[0];
 
     //
     //  This can happen if something goes wrong in the open and the file fails
@@ -566,9 +570,9 @@ static FcStatus lp1612Func(PpWord funcCode)
     //
     if (fcb == NULL)
         {
-        fprintf(stderr, "(lp1612 ) lp1612Io: FCB is null on channel %o equipment %o\n",
-                activeDevice->channel->id,
-                activeDevice->eqNo);
+        logDtError(LogErrorLocation, "Io: FCB is null on channel %o equipment %o\n",
+                   activeDevice->channel->id,
+                   activeDevice->eqNo);
 
         return FcProcessed;
         }
@@ -597,7 +601,7 @@ static FcStatus lp1612Func(PpWord funcCode)
         lp1612DebugData(lc);
 #endif
         switch (lc->renderingMode)
-            {
+        {
         default:
         case ModeCDC:
             lp1612PrintCDC(lc, fcb);
@@ -610,7 +614,7 @@ static FcStatus lp1612Func(PpWord funcCode)
         case ModeASCII:
             lp1612PrintASCII(lc, fcb);
             break;
-            }
+        }
         lc->linePos = 0;
         break;
 
@@ -618,7 +622,7 @@ static FcStatus lp1612Func(PpWord funcCode)
     case FcPrintDouble:
     case FcPrintMoveChannel7:
     case FcPrintEject:
-        if (lc->prePrintFunc != 0 && lc->prePrintFunc != FcPrintNoSpace)
+        if ((lc->prePrintFunc != 0) && (lc->prePrintFunc != FcPrintNoSpace))
             {
             fputs(lp1612FeForPrePrint(lc, lc->prePrintFunc), fcb);
             fputc('\n', fcb);
@@ -663,8 +667,8 @@ static FcStatus lp1612Func(PpWord funcCode)
 **------------------------------------------------------------------------*/
 static void lp1612Io(void)
     {
-    LpContext *lc = (LpContext *)activeDevice->context[0];
-    FILE *fcb         = activeDevice->fcb[0];
+    LpContext *lc  = (LpContext *)activeDevice->context[0];
+    FILE      *fcb = activeDevice->fcb[0];
 
     //
     //  This can happen if something goes wrong in the open and the file fails
@@ -672,9 +676,9 @@ static void lp1612Io(void)
     //
     if (fcb == NULL)
         {
-        fprintf(stderr, "(lp1612 ) lp1612Io: FCB is null on channel %o equipment %o\n",
-                activeDevice->channel->id,
-                activeDevice->eqNo);
+        logDtError(LogErrorLocation, "Io: FCB is null on channel %o equipment %o\n",
+                   activeDevice->channel->id,
+                   activeDevice->eqNo);
 
         return;
         }
@@ -689,8 +693,11 @@ static void lp1612Io(void)
     else if (activeChannel->full)
         {
 #if DEBUG
-       if (lc->linePos % 16 == 0) fputs("\n   ", lp1612Log);
-       fprintf(lp1612Log, " %04o", activeChannel->data);
+        if (lc->linePos % 16 == 0)
+            {
+            fputs("\n   ", lp1612Log);
+            }
+        fprintf(lp1612Log, " %04o", activeChannel->data);
 #endif
         if (lc->linePos < MaxLineSize)
             {
@@ -752,12 +759,12 @@ static void lp1612PrintANSI(LpContext *lc, FILE *fcb)
         {
         lc->prePrintFunc = 0;
         }
-    if (lc->postPrintFunc != 0 && lc->postPrintFunc != FcPrintFormat1 && lc->doSuppress == FALSE)
+    if ((lc->postPrintFunc != 0) && (lc->postPrintFunc != FcPrintFormat1) && (lc->doSuppress == FALSE))
         {
         lc->prePrintFunc = lc->postPrintFunc;
         }
     lc->doSuppress = FALSE;
-    if (fe == NULL || *fe != '+' || lc->linePos > 0)
+    if ((fe == NULL) || (*fe != '+') || (lc->linePos > 0))
         {
         fputs(fe != NULL ? fe : " ", fcb);
         for (i = 0; i < lc->linePos; i++)
@@ -832,22 +839,28 @@ static void lp1612PrintCDC(LpContext *lc, FILE *fcb)
         {
         lc->prePrintFunc = 0;
         }
-    if (lc->postPrintFunc != 0 && lc->postPrintFunc != FcPrintFormat1 && lc->doSuppress == FALSE)
+    if ((lc->postPrintFunc != 0) && (lc->postPrintFunc != FcPrintFormat1) && (lc->doSuppress == FALSE))
         {
         postFE = lp1612FeForPostPrint(lc, lc->postPrintFunc);
         }
     lc->doSuppress = FALSE;
     if (preFE != NULL)
         {
-        if (*preFE == '+' && lc->linePos < 1 && postFE == NULL) return;
+        if ((*preFE == '+') && (lc->linePos < 1) && (postFE == NULL))
+            {
+            return;
+            }
         fputs(preFE, fcb);
-        if (postFE != NULL) fputc('\n', fcb);
+        if (postFE != NULL)
+            {
+            fputc('\n', fcb);
+            }
         }
     if (postFE != NULL)
         {
         fputs(postFE, fcb);
         }
-    if (preFE == NULL && postFE == NULL)
+    if ((preFE == NULL) && (postFE == NULL))
         {
         fputc(' ', fcb);
         if (lc->doSuppress)
@@ -878,8 +891,10 @@ static char *lp1612FeForPostPrint(LpContext *lc, PpWord func)
         {
     case ModeCDC:
         switch (func)
-            {
-        default            : return "";
+        {
+        default:
+            return "";
+
         case FcPrintFormat1:
         case FcPrintFormat2:
         case FcPrintFormat3:
@@ -887,8 +902,9 @@ static char *lp1612FeForPostPrint(LpContext *lc, PpWord func)
         case FcPrintFormat5:
         case FcPrintFormat6:
             return postPrintCdcEffectors[lc->postPrintFunc - FcPrintFormat1];
-            }
+        }
         break;
+
     case ModeANSI:
     case ModeASCII:
     default:
@@ -913,25 +929,48 @@ static char *lp1612FeForPrePrint(LpContext *lc, PpWord func)
     default:
     case ModeCDC:
         switch (func)
-            {
-        default                  : return " ";
-        case FcPrintSingle       : return "0";
-        case FcPrintDouble       : return "-";
-        case FcPrintMoveChannel7 : return "2";
-        case FcPrintEject        : return "1";
-        case FcPrintNoSpace      : return "+";
-            }
+        {
+        default:
+            return " ";
+
+        case FcPrintSingle:
+            return "0";
+
+        case FcPrintDouble:
+            return "-";
+
+        case FcPrintMoveChannel7:
+            return "2";
+
+        case FcPrintEject:
+            return "1";
+
+        case FcPrintNoSpace:
+            return "+";
+        }
         break;
 
     case ModeANSI:
         switch (func)
-            {
-        default                  : return " ";
-        case FcPrintSingle       : return "0";
-        case FcPrintDouble       : return "-";
-        case FcPrintMoveChannel7 : return "7";
-        case FcPrintEject        : return "1";
-        case FcPrintNoSpace      : return "+";
+        {
+        default:
+            return " ";
+
+        case FcPrintSingle:
+            return "0";
+
+        case FcPrintDouble:
+            return "-";
+
+        case FcPrintMoveChannel7:
+            return "7";
+
+        case FcPrintEject:
+            return "1";
+
+        case FcPrintNoSpace:
+            return "+";
+
         case FcPrintFormat1:
         case FcPrintFormat2:
         case FcPrintFormat3:
@@ -939,22 +978,30 @@ static char *lp1612FeForPrePrint(LpContext *lc, PpWord func)
         case FcPrintFormat5:
         case FcPrintFormat6:
             return prePrintAnsiEffectors[lc->postPrintFunc - FcPrintFormat1];
-            }
+        }
         break;
 
     case ModeASCII:
         switch (func)
-            {
-        default            : return "";
-        case FcPrintSingle : return "\n";
-        case FcPrintDouble : return "\n\n";
-        case FcPrintEject  : return "\f";
-            }
+        {
+        default:
+            return "";
+
+        case FcPrintSingle:
+            return "\n";
+
+        case FcPrintDouble:
+            return "\n\n";
+
+        case FcPrintEject:
+            return "\f";
+        }
         break;
         }
     }
 
 #if DEBUG
+
 /*--------------------------------------------------------------------------
 **  Purpose:        Dump raw line data.
 **
@@ -971,7 +1018,7 @@ static void lp1612DebugData(LpContext *lc)
     if (lc->linePos > 0)
         {
         fprintf(lp1612Log, "\n    prePrintFunc:%04o  postPrintFunc:%04o  doSuppress:%s",
-            lc->prePrintFunc, lc->postPrintFunc, lc->doSuppress ? "TRUE" : "FALSE");
+                lc->prePrintFunc, lc->postPrintFunc, lc->doSuppress ? "TRUE" : "FALSE");
         for (i = 0; i < lc->linePos; i++)
             {
             if (i % 136 == 0)
@@ -999,27 +1046,59 @@ static char *lp1612Func2String(PpWord funcCode)
 
     switch (funcCode)
         {
-    default: break;
-    case FcPrintSelect       : return "FcPrintSelect";
-    case FcPrintSingle       : return "FcPrintSingle";
-    case FcPrintDouble       : return "FcPrintDouble";
-    case FcPrintMoveChannel7 : return "FcPrintMoveChannel7";
-    case FcPrintEject        : return "FcPrintEject";
-    case FcPrintPrint        : return "FcPrintPrint";
-    case FcPrintNoSpace      : return "FcPrintNoSpace";
-    case FcPrintStatusReq    : return "FcPrintStatusReq";
-    case FcPrintClearFormat  : return "FcPrintClearFormat";
-    case FcPrintFormat1      : return "FcPrintFormat1";
-    case FcPrintFormat2      : return "FcPrintFormat2";
-    case FcPrintFormat3      : return "FcPrintFormat3";
-    case FcPrintFormat4      : return "FcPrintFormat4";
-    case FcPrintFormat5      : return "FcPrintFormat5";
-    case FcPrintFormat6      : return "FcPrintFormat6";
+    default:
+        break;
+
+    case FcPrintSelect:
+        return "FcPrintSelect";
+
+    case FcPrintSingle:
+        return "FcPrintSingle";
+
+    case FcPrintDouble:
+        return "FcPrintDouble";
+
+    case FcPrintMoveChannel7:
+        return "FcPrintMoveChannel7";
+
+    case FcPrintEject:
+        return "FcPrintEject";
+
+    case FcPrintPrint:
+        return "FcPrintPrint";
+
+    case FcPrintNoSpace:
+        return "FcPrintNoSpace";
+
+    case FcPrintStatusReq:
+        return "FcPrintStatusReq";
+
+    case FcPrintClearFormat:
+        return "FcPrintClearFormat";
+
+    case FcPrintFormat1:
+        return "FcPrintFormat1";
+
+    case FcPrintFormat2:
+        return "FcPrintFormat2";
+
+    case FcPrintFormat3:
+        return "FcPrintFormat3";
+
+    case FcPrintFormat4:
+        return "FcPrintFormat4";
+
+    case FcPrintFormat5:
+        return "FcPrintFormat5";
+
+    case FcPrintFormat6:
+        return "FcPrintFormat6";
         }
     sprintf(buf, "Unknown Function: %04o", funcCode);
 
     return (buf);
     }
+
 #endif
 
 /*---------------------------  End Of File  ------------------------------*/

--- a/lp3000.c
+++ b/lp3000.c
@@ -1476,7 +1476,7 @@ static char *lp3000FeForPostPrint(LpContext *lc, u8 func)
         if (lc->flags & Lp3000Type3555)
             {
             switch (func)
-            {
+                {
             default:
                 return "";
 
@@ -1493,12 +1493,12 @@ static char *lp3000FeForPostPrint(LpContext *lc, u8 func)
             case Fc3555PostVFU11:
             case Fc3555PostVFU12:
                 return postPrintCdcEffectors[lc->postPrintFunc - Fc3555PostVFU1];
-            }
+                }
             }
         else
             {
             switch (func)
-            {
+                {
             default:
                 return "";
 
@@ -1509,7 +1509,7 @@ static char *lp3000FeForPostPrint(LpContext *lc, u8 func)
             case Fc3152PostVFU5:
             case Fc3152PostVFU6:
                 return postPrintCdcEffectors[lc->postPrintFunc - Fc3152PostVFU1];
-            }
+                }
             }
 
     case ModeANSI:
@@ -1538,7 +1538,7 @@ static char *lp3000FeForPrePrint(LpContext *lc, u8 func)
         if (lc->flags & Lp3000Type3555)
             {
             switch (func)
-            {
+                {
             default:
                 return " ";
 
@@ -1570,12 +1570,12 @@ static char *lp3000FeForPrePrint(LpContext *lc, u8 func)
             case Fc3555PreVFU11:
             case Fc3555PreVFU12:
                 return prePrintCdcEffectors[lc->prePrintFunc - Fc3555PreVFU1];
-            }
+                }
             }
         else
             {
             switch (lc->prePrintFunc)
-            {
+                {
             default:
                 return " ";
 
@@ -1601,7 +1601,7 @@ static char *lp3000FeForPrePrint(LpContext *lc, u8 func)
             case Fc3152PreVFU5:
             case Fc3152PreVFU6:
                 return prePrintCdcEffectors[lc->prePrintFunc - Fc3152PreVFU1];
-            }
+                }
             }
         break;
 
@@ -1609,7 +1609,7 @@ static char *lp3000FeForPrePrint(LpContext *lc, u8 func)
         if (lc->flags & Lp3000Type3555)
             {
             switch (func)
-            {
+                {
             default:
                 return " ";
 
@@ -1641,12 +1641,12 @@ static char *lp3000FeForPrePrint(LpContext *lc, u8 func)
             case Fc3555PreVFU11:
             case Fc3555PreVFU12:
                 return prePrintAnsiEffectors[lc->prePrintFunc - Fc3555PreVFU1];
-            }
+                }
             }
         else
             {
             switch (lc->prePrintFunc)
-            {
+                {
             default:
                 return " ";
 
@@ -1672,13 +1672,13 @@ static char *lp3000FeForPrePrint(LpContext *lc, u8 func)
             case Fc3152PreVFU5:
             case Fc3152PreVFU6:
                 return prePrintAnsiEffectors[lc->prePrintFunc - Fc3152PreVFU1];
-            }
+                }
             }
         break;
 
     case ModeASCII:
         switch (func)
-        {
+            {
         default:
             return "";
 
@@ -1690,7 +1690,7 @@ static char *lp3000FeForPrePrint(LpContext *lc, u8 func)
 
         case FcPrintEject:
             return "\f";
-        }
+            }
         }
     }
 

--- a/lp3000.c
+++ b/lp3000.c
@@ -151,7 +151,7 @@
 #define Fc3555MaintStatus        00065
 #define Fc3555ClearMaint         00066
 
-/*  
+/*
 **  Output rendering modes
 */
 #define ModeCDC                  0
@@ -211,7 +211,7 @@ typedef struct lpContext
 
     bool             doBurst;            //  bursting option for forced segmentation at EOJ
     char             path[MaxFSPath];    //  preserve the device folder path
-    char             curFileName[MaxFSPath+128];
+    char             curFileName[MaxFSPath + 128];
     } LpContext;
 
 
@@ -234,6 +234,7 @@ static void     lp3000PrintCDC(LpContext *lc, FILE *fcb);
 #if DEBUG
 static void     lp3000DebugData(LpContext *lc);
 static char    *lp3000Func2String(LpContext *lc, PpWord funcCode);
+
 #endif
 
 /*
@@ -251,7 +252,8 @@ static char    *lp3000Func2String(LpContext *lc, PpWord funcCode);
 static LpContext *firstUnit = NULL;
 static LpContext *lastUnit  = NULL;
 
-static char *postPrintCdcEffectors[] = {
+static char *postPrintCdcEffectors[] =
+    {
     "H", // advance to channel 1
     "G", // advance to channel 2
     "F", // advance to channel 3
@@ -264,9 +266,10 @@ static char *postPrintCdcEffectors[] = {
     "L", // advance to channel 10
     "M", // advance to channel 11
     "N"  // advance to channel 12
-};
+    };
 
-static char *prePrintAnsiEffectors[] = {
+static char *prePrintAnsiEffectors[] =
+    {
     "1", // advance to channel 1
     "2", // advance to channel 2
     "3", // advance to channel 3
@@ -279,9 +282,10 @@ static char *prePrintAnsiEffectors[] = {
     "A", // advance to channel 10
     "B", // advance to channel 11
     "C"  // advance to channel 12
-};
+    };
 
-static char *prePrintCdcEffectors[] = {
+static char *prePrintCdcEffectors[] =
+    {
     "8", // advance to channel 1
     "7", // advance to channel 2
     "6", // advance to channel 3
@@ -294,13 +298,14 @@ static char *prePrintCdcEffectors[] = {
     "Z", // advance to channel 10
     "W", // advance to channel 11
     "U"  // advance to channel 12
-};
+    };
 
-static char *renderingModes[] = {
+static char *renderingModes[] =
+    {
     "CDC",
     "ANSI",
     "ASCII"
-};
+    };
 
 #if DEBUG
 static FILE *lp3000Log = NULL;
@@ -437,7 +442,7 @@ static void lp3000Init(u16 lpType, u8 eqNo, u8 unitNo, u8 channelNo, char *devic
             }
         else
             {
-            fprintf(stderr, "(lp3000 ) %s Unrecognized output rendering mode '%s'\n", lpTypeName, deviceMode);
+            logDtError(LogErrorLocation, "%s Unrecognized output rendering mode '%s'\n", lpTypeName, deviceMode);
             exit(1);
             }
         }
@@ -452,13 +457,13 @@ static void lp3000Init(u16 lpType, u8 eqNo, u8 unitNo, u8 channelNo, char *devic
         {
         if (strcasecmp(burstMode, "burst") == 0)
             {
-            if (strcasecmp(osType, "nos") == 0 || strcasecmp(osType, "kronos") == 0)
+            if ((strcasecmp(osType, "nos") == 0) || (strcasecmp(osType, "kronos") == 0))
                 {
                 isBursting = TRUE;
                 }
             else
                 {
-                fprintf(stderr, "(lp3000 ) %s WARNING: BURST mode ignored; applies only to NOS operating systems\n", lpTypeName);
+                logDtError(LogErrorLocation, "%s WARNING: BURST mode ignored; applies only to NOS operating systems\n", lpTypeName);
                 }
             }
         else if (strcasecmp(burstMode, "noburst") == 0)
@@ -467,14 +472,14 @@ static void lp3000Init(u16 lpType, u8 eqNo, u8 unitNo, u8 channelNo, char *devic
             }
         else
             {
-            fprintf(stderr, "(lp3000 ) %s Unrecognized BURST mode '%s'\n", lpTypeName, burstMode);
+            logDtError(LogErrorLocation, "%s Unrecognized BURST mode '%s'\n", lpTypeName, burstMode);
             exit(1);
             }
         }
     fprintf(stdout, "(lp3000 ) %s Burst mode '%s'\n", lpTypeName, isBursting ? "Bursting" : "Non-Bursting");
 
-    if (deviceType == NULL
-        || strcmp(deviceType, "3555") == 0)
+    if ((deviceType == NULL)
+        || (strcmp(deviceType, "3555") == 0))
         {
         flags |= Lp3000Type3555;
         }
@@ -484,7 +489,7 @@ static void lp3000Init(u16 lpType, u8 eqNo, u8 unitNo, u8 channelNo, char *devic
         }
     else
         {
-        fprintf(stderr, "(lp3000 ) Unrecognized %s controller type %s\n", lpTypeName, deviceType);
+        logDtError(LogErrorLocation, "Unrecognized %s controller type %s\n", lpTypeName, deviceType);
         exit(1);
         }
 
@@ -500,18 +505,18 @@ static void lp3000Init(u16 lpType, u8 eqNo, u8 unitNo, u8 channelNo, char *devic
     */
     if (up->context[0] != NULL)
         {
-        fprintf(stderr, "(lp3000 ) Only one LP5xx unit is possible per equipment\n");
+        logDtError(LogErrorLocation, "Only one LP5xx unit is possible per equipment\n");
         exit(1);
         }
 
     lc = (LpContext *)calloc(1, sizeof(LpContext));
     if (lc == NULL)
         {
-        fprintf(stderr, "(lp3000 ) Failed to allocate LP5xx context block\n");
+        logDtError(LogErrorLocation, "Failed to allocate LP5xx context block\n");
         exit(1);
         }
 
-    up->context[0] = (void *)lc;
+    up->context[0]    = (void *)lc;
     lc->flags         = flags;
     lc->lpi           = 6;               //  Default print density
     lc->linePos       = 0;
@@ -550,7 +555,7 @@ static void lp3000Init(u16 lpType, u8 eqNo, u8 unitNo, u8 channelNo, char *devic
     up->fcb[0] = fopen(lc->curFileName, "w");
     if (up->fcb[0] == NULL)
         {
-        fprintf(stderr, "(lp3000 ) Failed to open %s\n", lc->curFileName);
+        logDtError(LogErrorLocation, "Failed to open %s\n", lc->curFileName);
         exit(1);
         }
 
@@ -589,7 +594,7 @@ void lp3000ShowStatus()
     {
     LpContext *lc;
     char      lpType[10];
-    char      outBuf[MaxFSPath+128];
+    char      outBuf[MaxFSPath + 128];
 
     for (lc = firstUnit; lc != NULL; lc = lc->nextUnit)
         {
@@ -601,7 +606,10 @@ void lp3000ShowStatus()
         opDisplay(renderingModes[lc->renderingMode]);
         sprintf(outBuf, ", %d lpi", lc->lpi);
         opDisplay(outBuf);
-        if (lc->doBurst) opDisplay(", burst");
+        if (lc->doBurst)
+            {
+            opDisplay(", burst");
+            }
         opDisplay(")\n");
         }
     }
@@ -621,11 +629,11 @@ void lp3000RemovePaper(char *params)
     time_t    currentTime;
     DevSlot   *dp;
     int       equipmentNo;
-    char      fNameNew[MaxFSPath+128];
+    char      fNameNew[MaxFSPath + 128];
     int       iSuffix;
     LpContext *lc;
     int       numParam;
-    char      outBuf[MaxFSPath*2+300];
+    char      outBuf[MaxFSPath * 2 + 300];
     bool      renameOK;
     struct tm t;
 
@@ -670,7 +678,7 @@ void lp3000RemovePaper(char *params)
         return;
         }
 
-    lc = (LpContext *)dp->context[0];
+    lc       = (LpContext *)dp->context[0];
     renameOK = FALSE;
 
     //
@@ -679,9 +687,9 @@ void lp3000RemovePaper(char *params)
     //
     if (dp->fcb[0] == NULL)
         {
-        fprintf(stderr, "(lp3000 ) lp3000RemovePaper: FCB is null on channel %o equipment %o\n",
-               dp->channel->id,
-               dp->eqNo);
+        logDtError(LogErrorLocation, "lp3000RemovePaper: FCB is null on channel %o equipment %o\n",
+                   dp->channel->id,
+                   dp->eqNo);
         //  proceed to attempt to open a new FCB
         }
     else
@@ -692,6 +700,7 @@ void lp3000RemovePaper(char *params)
             {
             sprintf(outBuf, "(lp3000 ) No output has been written on channel %o and equipment %o\n", channelNo, equipmentNo);
             opDisplay(outBuf);
+
             return;
             }
 
@@ -737,11 +746,11 @@ void lp3000RemovePaper(char *params)
                     renameOK = TRUE;
                     break;
                     }
-                fprintf(stderr, "(lp3000 ) Rename Failure '%s' to '%s' - (%s). Retrying (%d)...\n",
-                        lc->curFileName,
-                        fNameNew,
-                        strerror(errno),
-                        iSuffix);
+                logDtError(LogErrorLocation, "Rename Failure '%s' to '%s' - (%s). Retrying (%d)...\n",
+                           lc->curFileName,
+                           fNameNew,
+                           strerror(errno),
+                           iSuffix);
                 }
             }
         }
@@ -758,7 +767,7 @@ void lp3000RemovePaper(char *params)
     */
     if (dp->fcb[0] == NULL)
         {
-        fprintf(stderr, "Failed to open %s\n", lc->curFileName);
+        logDtError(LogErrorLocation, "Failed to open %s\n", lc->curFileName);
 
         return;
         }
@@ -796,9 +805,9 @@ static FcStatus lp3000Func(PpWord funcCode)
     */
     if (fcb == NULL)
         {
-        fprintf(stderr, "(lp3000 ) lp3000Func: FCB is null on channel %o equipment %o\n",
-                active3000Device->channel->id,
-                active3000Device->eqNo);
+        logDtError(LogErrorLocation, "lp3000Func: FCB is null on channel %o equipment %o\n",
+                   active3000Device->channel->id,
+                   active3000Device->eqNo);
 
         return FcProcessed;
         }
@@ -818,11 +827,16 @@ static FcStatus lp3000Func(PpWord funcCode)
         {
     case FcPrintNoSpace:
         lc->doSuppress = TRUE;
+
         return FcProcessed;
 
     case FcPrintAutoEject:
-        if (lc->renderingMode != ModeASCII && lc->doAutoEject == FALSE) fputs("R\n", fcb);
+        if ((lc->renderingMode != ModeASCII) && (lc->doAutoEject == FALSE))
+            {
+            fputs("R\n", fcb);
+            }
         lc->doAutoEject = TRUE;
+
         return FcProcessed;
 
     case Fc6681MasterClear:
@@ -833,6 +847,7 @@ static FcStatus lp3000Func(PpWord funcCode)
         lc->doAutoEject   = FALSE;
         lc->doSuppress    = FALSE;
         lc->flags        &= ~Lp3000ExtArray;
+
         return FcProcessed;
 
     case FcPrintRelease:
@@ -849,18 +864,20 @@ static FcStatus lp3000Func(PpWord funcCode)
             lp3000RemovePaper(dispLpDevId);
             }
         lc->isPrinted = FALSE;
+
         return FcProcessed;
 
     case FcPrintSingle:
     case FcPrintDouble:
     case FcPrintLastLine:
     case FcPrintEject:
-        if (lc->prePrintFunc != 0 && lc->prePrintFunc != FcPrintNoSpace)
+        if ((lc->prePrintFunc != 0) && (lc->prePrintFunc != FcPrintNoSpace))
             {
             fputs(lp3000FeForPrePrint(lc, lc->prePrintFunc), fcb);
             fputc('\n', fcb);
             }
         lc->prePrintFunc = (u8)funcCode;
+
         return FcProcessed;
 
     case Fc6681Output:
@@ -889,10 +906,12 @@ static FcStatus lp3000Func(PpWord funcCode)
         // Update interrupt summary flag in unit block
         dcc6681Interrupt((lc->flags & (Lp3000IntReady | Lp3000IntEnd)) != 0);
         active3000Device->fcode = funcCode;
+
         return FcAccepted;
 
     case Fc6681DevStatusReq:
         active3000Device->fcode = funcCode;
+
         return FcAccepted;
         }
 
@@ -901,27 +920,41 @@ static FcStatus lp3000Func(PpWord funcCode)
         switch (funcCode)
             {
         default:
-            fprintf(stderr, "(lp3000 ) Unknown LP3555 function %04o\n", funcCode);
+            logDtError(LogErrorLocation, "Unknown LP3555 function %04o\n", funcCode);
+
             return FcDeclined;
 
         case Fc3555Sel8Lpi:
-            if (lc->renderingMode != ModeASCII && lc->lpi != 8) fputs("T\n", fcb);
+            if ((lc->renderingMode != ModeASCII) && (lc->lpi != 8))
+                {
+                fputs("T\n", fcb);
+                }
             lc->lpi = 8;
+
             return FcProcessed;
 
         case Fc3555Sel6Lpi:
-            if (lc->renderingMode != ModeASCII && lc->lpi != 6) fputs("S\n", fcb);
+            if ((lc->renderingMode != ModeASCII) && (lc->lpi != 6))
+                {
+                fputs("S\n", fcb);
+                }
             lc->lpi = 6;
+
             return FcProcessed;
 
         case Fc3555ClearFormat:
-            if (lc->renderingMode != ModeASCII
-                && (lc->lpi != 6 || lc->doAutoEject)) fputs("Q\n", fcb);
+            if ((lc->renderingMode != ModeASCII)
+                && ((lc->lpi != 6) || lc->doAutoEject))
+                {
+                fputs("Q\n", fcb);
+                }
+
         case Fc3555CondClearFormat:
             lc->postPrintFunc = 0;
             lc->lpi           = 6;
             lc->doAutoEject   = FALSE;
             lc->doSuppress    = FALSE;
+
             return FcProcessed;
 
         case Fc3555PostVFU1:
@@ -937,10 +970,12 @@ static FcStatus lp3000Func(PpWord funcCode)
         case Fc3555PostVFU11:
         case Fc3555PostVFU12:
             lc->postPrintFunc = (u8)funcCode;
+
             return FcProcessed;
 
         case Fc3555SelectPrePrint:
             lc->postPrintFunc = 0;
+
             return FcProcessed;
 
         case Fc3555PreVFU1:
@@ -956,12 +991,14 @@ static FcStatus lp3000Func(PpWord funcCode)
         case Fc3555PreVFU11:
         case Fc3555PreVFU12:
             lc->prePrintFunc = (u8)funcCode;
+
             return FcProcessed;
 
         case Fc3555FillMemory:
             // Remember that we saw this function, but this doesn't actually
             // start any I/O yet.
             lc->flags |= Lp3555FillImageMem;
+
             return FcProcessed;
 
         case Fc3555SelIntReady:
@@ -982,12 +1019,14 @@ static FcStatus lp3000Func(PpWord funcCode)
                 }
             // Update interrupt summary flag in unit block
             dcc6681Interrupt((lc->flags & (Lp3000IntReady | Lp3000IntEnd)) != 0);
+
             return FcProcessed;
 
         case Fc3555RelIntReady:
             lc->flags &= ~(Lp3000IntReadyEna | Lp3000IntReady);
             // Update interrupt summary flag in unit block
             dcc6681Interrupt((lc->flags & (Lp3000IntReady | Lp3000IntEnd)) != 0);
+
             return FcProcessed;
 
         case Fc3555SelIntEnd:
@@ -1002,20 +1041,24 @@ static FcStatus lp3000Func(PpWord funcCode)
                 }
             // Update interrupt summary flag in unit block
             dcc6681Interrupt((lc->flags & (Lp3000IntReady | Lp3000IntEnd)) != 0);
+
             return FcProcessed;
 
         case Fc3555RelIntEnd:
             lc->flags &= ~(Lp3000IntEndEna | Lp3000IntEnd);
             // Update interrupt summary flag in unit block
             dcc6681Interrupt((lc->flags & (Lp3000IntReady | Lp3000IntEnd)) != 0);
+
             return FcProcessed;
 
         case Fc3555SelExtArray:
             lc->flags |= Lp3000ExtArray;
+
             return FcProcessed;
 
         case Fc3555ClearExtArray:
             lc->flags &= ~Lp3000ExtArray;
+
             return FcProcessed;
 
         case Fc3555SelIntError:
@@ -1039,16 +1082,21 @@ static FcStatus lp3000Func(PpWord funcCode)
             //
             if (funcCode != Fc3555SelectPrePrint)
                 {
-                fprintf(stderr, "(lp3000 ) Unknown LP3152 function %04o\n", funcCode);
+                logDtError(LogErrorLocation, "Unknown LP3152 function %04o\n", funcCode);
                 }
+
             return FcDeclined;
 
         case Fc3152ClearFormat:
-            if (lc->renderingMode != ModeASCII && lc->doAutoEject) fputs("Q\n", fcb);
+            if ((lc->renderingMode != ModeASCII) && lc->doAutoEject)
+                {
+                fputs("Q\n", fcb);
+                }
             lc->postPrintFunc = 0;
             lc->lpi           = 6;
             lc->doAutoEject   = FALSE;
             lc->doSuppress    = FALSE;
+
             return FcProcessed;
 
         case Fc3152PostVFU1:
@@ -1058,10 +1106,12 @@ static FcStatus lp3000Func(PpWord funcCode)
         case Fc3152PostVFU5:
         case Fc3152PostVFU6:
             lc->postPrintFunc = (u8)funcCode;
+
             return FcProcessed;
 
         case Fc3152SelectPrePrint:
             lc->postPrintFunc = 0;
+
             return FcProcessed;
 
         case Fc3152PreVFU1:
@@ -1071,6 +1121,7 @@ static FcStatus lp3000Func(PpWord funcCode)
         case Fc3152PreVFU5:
         case Fc3152PreVFU6:
             lc->prePrintFunc = (u8)funcCode;
+
             return FcProcessed;
 
         case Fc3152SelIntReady:
@@ -1091,12 +1142,14 @@ static FcStatus lp3000Func(PpWord funcCode)
                 }
             // Update interrupt summary flag in unit block
             dcc6681Interrupt((lc->flags & (Lp3000IntReady | Lp3000IntEnd)) != 0);
+
             return FcProcessed;
 
         case Fc3152RelIntReady:
             lc->flags &= ~(Lp3000IntReadyEna | Lp3000IntReady);
             // Update interrupt summary flag in unit block
             dcc6681Interrupt((lc->flags & (Lp3000IntReady | Lp3000IntEnd)) != 0);
+
             return FcProcessed;
 
         case Fc3152SelIntEnd:
@@ -1111,12 +1164,14 @@ static FcStatus lp3000Func(PpWord funcCode)
                 }
             // Update interrupt summary flag in unit block
             dcc6681Interrupt((lc->flags & (Lp3000IntReady | Lp3000IntEnd)) != 0);
+
             return FcProcessed;
 
         case Fc3152RelIntEnd:
             lc->flags &= ~(Lp3000IntEndEna | Lp3000IntEnd);
             // Update interrupt summary flag in unit block
             dcc6681Interrupt((lc->flags & (Lp3000IntReady | Lp3000IntEnd)) != 0);
+
             return FcProcessed;
 
         case Fc3152SelIntError:
@@ -1156,7 +1211,10 @@ static void lp3000Io(void)
         if (activeChannel->full)
             {
 #if DEBUG
-            if (lc->linePos % 16 == 0) fputs("\n   ", lp3000Log);
+            if (lc->linePos % 16 == 0)
+                {
+                fputs("\n   ", lp3000Log);
+                }
             fprintf(lp3000Log, " %04o", activeChannel->data);
 #endif
             if (lc->linePos < MaxLineSize)
@@ -1222,9 +1280,9 @@ static void lp3000Disconnect(void)
     //
     if (fcb == NULL)
         {
-        fprintf(stderr, "(lp3000 ) lp3000Disconnect: FCB is null on channel %o equipment %o\n",
-                active3000Device->channel->id,
-                active3000Device->eqNo);
+        logDtError(LogErrorLocation, "lp3000Disconnect: FCB is null on channel %o equipment %o\n",
+                   active3000Device->channel->id,
+                   active3000Device->eqNo);
 
         return;
         }
@@ -1240,9 +1298,11 @@ static void lp3000Disconnect(void)
         case ModeCDC:
             lp3000PrintCDC(lc, fcb);
             break;
+
         case ModeANSI:
             lp3000PrintANSI(lc, fcb);
             break;
+
         case ModeASCII:
             lp3000PrintASCII(lc, fcb);
             break;
@@ -1280,14 +1340,14 @@ static void lp3000PrintANSI(LpContext *lc, FILE *fcb)
         {
         lc->prePrintFunc = 0;
         }
-    if (lc->postPrintFunc != 0 && lc->doSuppress == FALSE)
+    if ((lc->postPrintFunc != 0) && (lc->doSuppress == FALSE))
         {
         lc->prePrintFunc = (lc->flags & Lp3000Type3555)
             ? (lc->postPrintFunc - Fc3555PostVFU1) + Fc3555PreVFU1
             : (lc->postPrintFunc - Fc3152PostVFU1) + Fc3152PreVFU1;
         }
     lc->doSuppress = FALSE;
-    if (fe == NULL || *fe != '+' || lc->linePos > 0)
+    if ((fe == NULL) || (*fe != '+') || (lc->linePos > 0))
         {
         fputs(fe != NULL ? fe : " ", fcb);
         for (i = 0; i < lc->linePos; i++)
@@ -1362,22 +1422,28 @@ static void lp3000PrintCDC(LpContext *lc, FILE *fcb)
         {
         lc->prePrintFunc = 0;
         }
-    if (lc->postPrintFunc != 0 && lc->doSuppress == FALSE)
+    if ((lc->postPrintFunc != 0) && (lc->doSuppress == FALSE))
         {
         postFE = lp3000FeForPostPrint(lc, lc->postPrintFunc);
         }
     lc->doSuppress = FALSE;
     if (preFE != NULL)
         {
-        if (*preFE == '+' && lc->linePos < 1 && postFE == NULL) return;
+        if ((*preFE == '+') && (lc->linePos < 1) && (postFE == NULL))
+            {
+            return;
+            }
         fputs(preFE, fcb);
-        if (postFE != NULL) fputc('\n', fcb);
+        if (postFE != NULL)
+            {
+            fputc('\n', fcb);
+            }
         }
     if (postFE != NULL)
         {
         fputs(postFE, fcb);
         }
-    if (preFE == NULL && postFE == NULL)
+    if ((preFE == NULL) && (postFE == NULL))
         {
         fputc(' ', fcb);
         if (lc->doSuppress)
@@ -1410,37 +1476,42 @@ static char *lp3000FeForPostPrint(LpContext *lc, u8 func)
         if (lc->flags & Lp3000Type3555)
             {
             switch (func)
-                {
-            default              : return "";
-            case Fc3555PostVFU1  :
-            case Fc3555PostVFU2  :
-            case Fc3555PostVFU3  :
-            case Fc3555PostVFU4  :
-            case Fc3555PostVFU5  :
-            case Fc3555PostVFU6  :
-            case Fc3555PostVFU7  :
-            case Fc3555PostVFU8  :
-            case Fc3555PostVFU9  :
-            case Fc3555PostVFU10 :
-            case Fc3555PostVFU11 :
-            case Fc3555PostVFU12 :
+            {
+            default:
+                return "";
+
+            case Fc3555PostVFU1:
+            case Fc3555PostVFU2:
+            case Fc3555PostVFU3:
+            case Fc3555PostVFU4:
+            case Fc3555PostVFU5:
+            case Fc3555PostVFU6:
+            case Fc3555PostVFU7:
+            case Fc3555PostVFU8:
+            case Fc3555PostVFU9:
+            case Fc3555PostVFU10:
+            case Fc3555PostVFU11:
+            case Fc3555PostVFU12:
                 return postPrintCdcEffectors[lc->postPrintFunc - Fc3555PostVFU1];
-                }
+            }
             }
         else
             {
             switch (func)
-                {
-            default              : return "";
-            case Fc3152PostVFU1  :
-            case Fc3152PostVFU2  :
-            case Fc3152PostVFU3  :
-            case Fc3152PostVFU4  :
-            case Fc3152PostVFU5  :
-            case Fc3152PostVFU6  :
+            {
+            default:
+                return "";
+
+            case Fc3152PostVFU1:
+            case Fc3152PostVFU2:
+            case Fc3152PostVFU3:
+            case Fc3152PostVFU4:
+            case Fc3152PostVFU5:
+            case Fc3152PostVFU6:
                 return postPrintCdcEffectors[lc->postPrintFunc - Fc3152PostVFU1];
-                }
             }
+            }
+
     case ModeANSI:
     case ModeASCII:
     default:
@@ -1467,46 +1538,70 @@ static char *lp3000FeForPrePrint(LpContext *lc, u8 func)
         if (lc->flags & Lp3000Type3555)
             {
             switch (func)
-                {
-            default              : return " ";
-            case FcPrintSingle   : return "0";
-            case FcPrintDouble   : return "-";
-            case FcPrintLastLine : return "2";
-            case FcPrintEject    : return "1";
-            case FcPrintNoSpace  : return "+";
-            case Fc3555PreVFU1   :
-            case Fc3555PreVFU2   :
-            case Fc3555PreVFU3   :
-            case Fc3555PreVFU4   :
-            case Fc3555PreVFU5   :
-            case Fc3555PreVFU6   :
-            case Fc3555PreVFU7   :
-            case Fc3555PreVFU8   :
-            case Fc3555PreVFU9   :
-            case Fc3555PreVFU10  :
-            case Fc3555PreVFU11  :
-            case Fc3555PreVFU12  :
+            {
+            default:
+                return " ";
+
+            case FcPrintSingle:
+                return "0";
+
+            case FcPrintDouble:
+                return "-";
+
+            case FcPrintLastLine:
+                return "2";
+
+            case FcPrintEject:
+                return "1";
+
+            case FcPrintNoSpace:
+                return "+";
+
+            case Fc3555PreVFU1:
+            case Fc3555PreVFU2:
+            case Fc3555PreVFU3:
+            case Fc3555PreVFU4:
+            case Fc3555PreVFU5:
+            case Fc3555PreVFU6:
+            case Fc3555PreVFU7:
+            case Fc3555PreVFU8:
+            case Fc3555PreVFU9:
+            case Fc3555PreVFU10:
+            case Fc3555PreVFU11:
+            case Fc3555PreVFU12:
                 return prePrintCdcEffectors[lc->prePrintFunc - Fc3555PreVFU1];
-                }
+            }
             }
         else
             {
             switch (lc->prePrintFunc)
-                {
-            default              : return " ";
-            case FcPrintSingle   : return "0";
-            case FcPrintDouble   : return "-";
-            case FcPrintLastLine : return "2";
-            case FcPrintEject    : return "1";
-            case FcPrintNoSpace  : return "+";
-            case Fc3152PreVFU1   :
-            case Fc3152PreVFU2   :
-            case Fc3152PreVFU3   :
-            case Fc3152PreVFU4   :
-            case Fc3152PreVFU5   :
-            case Fc3152PreVFU6   :
+            {
+            default:
+                return " ";
+
+            case FcPrintSingle:
+                return "0";
+
+            case FcPrintDouble:
+                return "-";
+
+            case FcPrintLastLine:
+                return "2";
+
+            case FcPrintEject:
+                return "1";
+
+            case FcPrintNoSpace:
+                return "+";
+
+            case Fc3152PreVFU1:
+            case Fc3152PreVFU2:
+            case Fc3152PreVFU3:
+            case Fc3152PreVFU4:
+            case Fc3152PreVFU5:
+            case Fc3152PreVFU6:
                 return prePrintCdcEffectors[lc->prePrintFunc - Fc3152PreVFU1];
-                }
+            }
             }
         break;
 
@@ -1514,61 +1609,93 @@ static char *lp3000FeForPrePrint(LpContext *lc, u8 func)
         if (lc->flags & Lp3000Type3555)
             {
             switch (func)
-                {
-            default              : return " ";
-            case FcPrintSingle   : return "0";
-            case FcPrintDouble   : return "-";
-            case FcPrintLastLine : return "C";
-            case FcPrintEject    : return "1";
-            case FcPrintNoSpace  : return "+";
-            case Fc3555PreVFU1   :
-            case Fc3555PreVFU2   :
-            case Fc3555PreVFU3   :
-            case Fc3555PreVFU4   :
-            case Fc3555PreVFU5   :
-            case Fc3555PreVFU6   :
-            case Fc3555PreVFU7   :
-            case Fc3555PreVFU8   :
-            case Fc3555PreVFU9   :
-            case Fc3555PreVFU10  :
-            case Fc3555PreVFU11  :
-            case Fc3555PreVFU12  :
+            {
+            default:
+                return " ";
+
+            case FcPrintSingle:
+                return "0";
+
+            case FcPrintDouble:
+                return "-";
+
+            case FcPrintLastLine:
+                return "C";
+
+            case FcPrintEject:
+                return "1";
+
+            case FcPrintNoSpace:
+                return "+";
+
+            case Fc3555PreVFU1:
+            case Fc3555PreVFU2:
+            case Fc3555PreVFU3:
+            case Fc3555PreVFU4:
+            case Fc3555PreVFU5:
+            case Fc3555PreVFU6:
+            case Fc3555PreVFU7:
+            case Fc3555PreVFU8:
+            case Fc3555PreVFU9:
+            case Fc3555PreVFU10:
+            case Fc3555PreVFU11:
+            case Fc3555PreVFU12:
                 return prePrintAnsiEffectors[lc->prePrintFunc - Fc3555PreVFU1];
-                }
+            }
             }
         else
             {
             switch (lc->prePrintFunc)
-                {
-            default              : return " ";
-            case FcPrintSingle   : return "0";
-            case FcPrintDouble   : return "-";
-            case FcPrintLastLine : return "C";
-            case FcPrintEject    : return "1";
-            case FcPrintNoSpace  : return "+";
-            case Fc3152PreVFU1   :
-            case Fc3152PreVFU2   :
-            case Fc3152PreVFU3   :
-            case Fc3152PreVFU4   :
-            case Fc3152PreVFU5   :
-            case Fc3152PreVFU6   :
+            {
+            default:
+                return " ";
+
+            case FcPrintSingle:
+                return "0";
+
+            case FcPrintDouble:
+                return "-";
+
+            case FcPrintLastLine:
+                return "C";
+
+            case FcPrintEject:
+                return "1";
+
+            case FcPrintNoSpace:
+                return "+";
+
+            case Fc3152PreVFU1:
+            case Fc3152PreVFU2:
+            case Fc3152PreVFU3:
+            case Fc3152PreVFU4:
+            case Fc3152PreVFU5:
+            case Fc3152PreVFU6:
                 return prePrintAnsiEffectors[lc->prePrintFunc - Fc3152PreVFU1];
-                }
+            }
             }
         break;
 
     case ModeASCII:
         switch (func)
-            {
-        default            : return "";
-        case FcPrintSingle : return "\n";
-        case FcPrintDouble : return "\n\n";
-        case FcPrintEject  : return "\f";
-            }
+        {
+        default:
+            return "";
+
+        case FcPrintSingle:
+            return "\n";
+
+        case FcPrintDouble:
+            return "\n\n";
+
+        case FcPrintEject:
+            return "\f";
+        }
         }
     }
 
 #if DEBUG
+
 /*--------------------------------------------------------------------------
 **  Purpose:        Dump raw line data.
 **
@@ -1585,7 +1712,7 @@ static void lp3000DebugData(LpContext *lc)
     if (lc->linePos > 0)
         {
         fprintf(lp3000Log, "\n    prePrintFunc:%04o  postPrintFunc:%04o  doSuppress:%s",
-            lc->prePrintFunc, lc->postPrintFunc, lc->doSuppress ? "TRUE" : "FALSE");
+                lc->prePrintFunc, lc->postPrintFunc, lc->doSuppress ? "TRUE" : "FALSE");
         for (i = 0; i < lc->linePos; i++)
             {
             if (i % 136 == 0)
@@ -1614,98 +1741,246 @@ static char *lp3000Func2String(LpContext *lc, PpWord funcCode)
 
     switch (funcCode)
         {
-    default: break;
-    case FcPrintRelease               : return "FcPrintRelease";
-    case FcPrintSingle                : return "FcPrintSingle";
-    case FcPrintDouble                : return "FcPrintDouble";
-    case FcPrintLastLine              : return "FcPrintLastLine";
-    case FcPrintEject                 : return "FcPrintEject";
-    case FcPrintAutoEject             : return "FcPrintAutoEject";
-    case FcPrintNoSpace               : return "FcPrintNoSpace";
-    case Fc6681MasterClear            : return "Fc6681MasterClear";
-    case Fc6681Output                 : return "Fc6681Output";
-    case Fc6681DevStatusReq           : return "Fc6681DevStatusReq";
+    default:
+        break;
+
+    case FcPrintRelease:
+        return "FcPrintRelease";
+
+    case FcPrintSingle:
+        return "FcPrintSingle";
+
+    case FcPrintDouble:
+        return "FcPrintDouble";
+
+    case FcPrintLastLine:
+        return "FcPrintLastLine";
+
+    case FcPrintEject:
+        return "FcPrintEject";
+
+    case FcPrintAutoEject:
+        return "FcPrintAutoEject";
+
+    case FcPrintNoSpace:
+        return "FcPrintNoSpace";
+
+    case Fc6681MasterClear:
+        return "Fc6681MasterClear";
+
+    case Fc6681Output:
+        return "Fc6681Output";
+
+    case Fc6681DevStatusReq:
+        return "Fc6681DevStatusReq";
         }
     if (lc->flags & Lp3000Type3555)             // This is LP3555
         {
         switch (funcCode)
             {
-        default: break;
-        case Fc3555CondClearFormat    : return "Fc3555CondClearFormat";
-        case Fc3555Sel8Lpi            : return "Fc3555Sel8Lpi";
-        case Fc3555Sel6Lpi            : return "Fc3555Sel6Lpi";
-        case Fc3555FillMemory         : return "Fc3555FillMemory";
-        case Fc3555SelExtArray        : return "Fc3555SelExtArray";
-        case Fc3555ClearExtArray      : return "Fc3555ClearExtArray";
-        case Fc3555SelIntReady        : return "Fc3555SelIntReady";
-        case Fc3555RelIntReady        : return "Fc3555RelIntReady";
-        case Fc3555SelIntEnd          : return "Fc3555SelIntEnd";
-        case Fc3555RelIntEnd          : return "Fc3555RelIntEnd";
-        case Fc3555SelIntError        : return "Fc3555SelIntError";
-        case Fc3555RelIntError        : return "Fc3555RelIntError";
-        case Fc3555ReloadMemEnable    : return "Fc3555ReloadMemEnable";
-        case Fc3555ClearFormat        : return "Fc3555ClearFormat";
-        case Fc3555PostVFU1           : return "Fc3555PostVFU1";
-        case Fc3555PostVFU2           : return "Fc3555PostVFU2";
-        case Fc3555PostVFU3           : return "Fc3555PostVFU3";
-        case Fc3555PostVFU4           : return "Fc3555PostVFU4";
-        case Fc3555PostVFU5           : return "Fc3555PostVFU5";
-        case Fc3555PostVFU6           : return "Fc3555PostVFU6";
-        case Fc3555PostVFU7           : return "Fc3555PostVFU7";
-        case Fc3555PostVFU8           : return "Fc3555PostVFU8";
-        case Fc3555PostVFU9           : return "Fc3555PostVFU9";
-        case Fc3555PostVFU10          : return "Fc3555PostVFU10";
-        case Fc3555PostVFU11          : return "Fc3555PostVFU11";
-        case Fc3555PostVFU12          : return "Fc3555PostVFU12";
-        case Fc3555SelectPrePrint     : return "Fc3555SelectPrePrint";
-        case Fc3555PreVFU1            : return "Fc3555PreVFU1";
-        case Fc3555PreVFU2            : return "Fc3555PreVFU2";
-        case Fc3555PreVFU3            : return "Fc3555PreVFU3";
-        case Fc3555PreVFU4            : return "Fc3555PreVFU4";
-        case Fc3555PreVFU5            : return "Fc3555PreVFU5";
-        case Fc3555PreVFU6            : return "Fc3555PreVFU6";
-        case Fc3555PreVFU7            : return "Fc3555PreVFU7";
-        case Fc3555PreVFU8            : return "Fc3555PreVFU8";
-        case Fc3555PreVFU9            : return "Fc3555PreVFU9";
-        case Fc3555PreVFU10           : return "Fc3555PreVFU10";
-        case Fc3555PreVFU11           : return "Fc3555PreVFU11";
-        case Fc3555PreVFU12           : return "Fc3555PreVFU12";
-        case Fc3555MaintStatus        : return "Fc3555MaintStatus";
-        case Fc3555ClearMaint         : return "Fc3555ClearMaint";
+        default:
+            break;
+
+        case Fc3555CondClearFormat:
+            return "Fc3555CondClearFormat";
+
+        case Fc3555Sel8Lpi:
+            return "Fc3555Sel8Lpi";
+
+        case Fc3555Sel6Lpi:
+            return "Fc3555Sel6Lpi";
+
+        case Fc3555FillMemory:
+            return "Fc3555FillMemory";
+
+        case Fc3555SelExtArray:
+            return "Fc3555SelExtArray";
+
+        case Fc3555ClearExtArray:
+            return "Fc3555ClearExtArray";
+
+        case Fc3555SelIntReady:
+            return "Fc3555SelIntReady";
+
+        case Fc3555RelIntReady:
+            return "Fc3555RelIntReady";
+
+        case Fc3555SelIntEnd:
+            return "Fc3555SelIntEnd";
+
+        case Fc3555RelIntEnd:
+            return "Fc3555RelIntEnd";
+
+        case Fc3555SelIntError:
+            return "Fc3555SelIntError";
+
+        case Fc3555RelIntError:
+            return "Fc3555RelIntError";
+
+        case Fc3555ReloadMemEnable:
+            return "Fc3555ReloadMemEnable";
+
+        case Fc3555ClearFormat:
+            return "Fc3555ClearFormat";
+
+        case Fc3555PostVFU1:
+            return "Fc3555PostVFU1";
+
+        case Fc3555PostVFU2:
+            return "Fc3555PostVFU2";
+
+        case Fc3555PostVFU3:
+            return "Fc3555PostVFU3";
+
+        case Fc3555PostVFU4:
+            return "Fc3555PostVFU4";
+
+        case Fc3555PostVFU5:
+            return "Fc3555PostVFU5";
+
+        case Fc3555PostVFU6:
+            return "Fc3555PostVFU6";
+
+        case Fc3555PostVFU7:
+            return "Fc3555PostVFU7";
+
+        case Fc3555PostVFU8:
+            return "Fc3555PostVFU8";
+
+        case Fc3555PostVFU9:
+            return "Fc3555PostVFU9";
+
+        case Fc3555PostVFU10:
+            return "Fc3555PostVFU10";
+
+        case Fc3555PostVFU11:
+            return "Fc3555PostVFU11";
+
+        case Fc3555PostVFU12:
+            return "Fc3555PostVFU12";
+
+        case Fc3555SelectPrePrint:
+            return "Fc3555SelectPrePrint";
+
+        case Fc3555PreVFU1:
+            return "Fc3555PreVFU1";
+
+        case Fc3555PreVFU2:
+            return "Fc3555PreVFU2";
+
+        case Fc3555PreVFU3:
+            return "Fc3555PreVFU3";
+
+        case Fc3555PreVFU4:
+            return "Fc3555PreVFU4";
+
+        case Fc3555PreVFU5:
+            return "Fc3555PreVFU5";
+
+        case Fc3555PreVFU6:
+            return "Fc3555PreVFU6";
+
+        case Fc3555PreVFU7:
+            return "Fc3555PreVFU7";
+
+        case Fc3555PreVFU8:
+            return "Fc3555PreVFU8";
+
+        case Fc3555PreVFU9:
+            return "Fc3555PreVFU9";
+
+        case Fc3555PreVFU10:
+            return "Fc3555PreVFU10";
+
+        case Fc3555PreVFU11:
+            return "Fc3555PreVFU11";
+
+        case Fc3555PreVFU12:
+            return "Fc3555PreVFU12";
+
+        case Fc3555MaintStatus:
+            return "Fc3555MaintStatus";
+
+        case Fc3555ClearMaint:
+            return "Fc3555ClearMaint";
             }
         }
     else
         {
         switch (funcCode)
             {
-        default: break;
-        case Fc3152ClearFormat        : return "Fc3152ClearFormat";
-        case Fc3152PostVFU1           : return "Fc3152PostVFU1";
-        case Fc3152PostVFU2           : return "Fc3152PostVFU2";
-        case Fc3152PostVFU3           : return "Fc3152PostVFU3";
-        case Fc3152PostVFU4           : return "Fc3152PostVFU4";
-        case Fc3152PostVFU5           : return "Fc3152PostVFU5";
-        case Fc3152PostVFU6           : return "Fc3152PostVFU6";
-        case Fc3152SelectPrePrint     : return "Fc3152SelectPrePrint";
-        case Fc3152PreVFU1            : return "Fc3152PreVFU1";
-        case Fc3152PreVFU2            : return "Fc3152PreVFU2";
-        case Fc3152PreVFU3            : return "Fc3152PreVFU3";
-        case Fc3152PreVFU4            : return "Fc3152PreVFU4";
-        case Fc3152PreVFU5            : return "Fc3152PreVFU5";
-        case Fc3152PreVFU6            : return "Fc3152PreVFU6";
-        case Fc3152SelIntReady        : return "Fc3152SelIntReady";
-        case Fc3152RelIntReady        : return "Fc3152RelIntReady";
-        case Fc3152SelIntEnd          : return "Fc3152SelIntEnd";
-        case Fc3152RelIntEnd          : return "Fc3152RelIntEnd";
-        case Fc3152SelIntError        : return "Fc3152SelIntError";
-        case Fc3152RelIntError        : return "Fc3152RelIntError";
-        case Fc3152Release2           : return "Fc3152Release2";
+        default:
+            break;
+
+        case Fc3152ClearFormat:
+            return "Fc3152ClearFormat";
+
+        case Fc3152PostVFU1:
+            return "Fc3152PostVFU1";
+
+        case Fc3152PostVFU2:
+            return "Fc3152PostVFU2";
+
+        case Fc3152PostVFU3:
+            return "Fc3152PostVFU3";
+
+        case Fc3152PostVFU4:
+            return "Fc3152PostVFU4";
+
+        case Fc3152PostVFU5:
+            return "Fc3152PostVFU5";
+
+        case Fc3152PostVFU6:
+            return "Fc3152PostVFU6";
+
+        case Fc3152SelectPrePrint:
+            return "Fc3152SelectPrePrint";
+
+        case Fc3152PreVFU1:
+            return "Fc3152PreVFU1";
+
+        case Fc3152PreVFU2:
+            return "Fc3152PreVFU2";
+
+        case Fc3152PreVFU3:
+            return "Fc3152PreVFU3";
+
+        case Fc3152PreVFU4:
+            return "Fc3152PreVFU4";
+
+        case Fc3152PreVFU5:
+            return "Fc3152PreVFU5";
+
+        case Fc3152PreVFU6:
+            return "Fc3152PreVFU6";
+
+        case Fc3152SelIntReady:
+            return "Fc3152SelIntReady";
+
+        case Fc3152RelIntReady:
+            return "Fc3152RelIntReady";
+
+        case Fc3152SelIntEnd:
+            return "Fc3152SelIntEnd";
+
+        case Fc3152RelIntEnd:
+            return "Fc3152RelIntEnd";
+
+        case Fc3152SelIntError:
+            return "Fc3152SelIntError";
+
+        case Fc3152RelIntError:
+            return "Fc3152RelIntError";
+
+        case Fc3152Release2:
+            return "Fc3152Release2";
             }
         }
     sprintf(buf, "Unknown Function: %04o", funcCode);
 
     return (buf);
     }
+
 #endif
 
 /*---------------------------  End Of File  ------------------------------*/

--- a/main.c
+++ b/main.c
@@ -52,6 +52,16 @@
 #include <unistd.h>
 #endif
 
+#if defined(_WIN32)
+extern int _write(
+    int          fd,
+    const void   *buffer,
+    unsigned int count
+    );
+extern int _isatty(int fd);
+
+#endif
+
 /*
 **  -----------------
 **  Private Constants
@@ -139,6 +149,7 @@ int main(int argc, char **argv)
     */
     atexit(opExit);
     timeBeginPeriod(8);
+
     /*
     **  Select WINSOCK 1.1.
     */
@@ -151,7 +162,7 @@ int main(int argc, char **argv)
     err = WSAStartup(versionRequested, &wsaData);
     if (err != 0)
         {
-        fprintf(stderr, "\n(main) Error in WSAStartup: %d\n", err);
+        logDtError(LogErrorLocation, "\n(main) Error in WSAStartup: %d\n", err);
         exit(1);
         }
 #else
@@ -181,11 +192,6 @@ int main(int argc, char **argv)
 
     //  Don't let the user press Ctrl-C by accident.
     signal(SIGINT, INThandler);
-
-    /*
-    **  Setup error logging.
-    */
-    logInit();
 
     /*
     **  Allow optional command line parameter to specify section to run in "cyber.ini".
@@ -241,7 +247,7 @@ int main(int argc, char **argv)
     */
     deadStart();
 
-    fputs("(cpu    ) CPU0 started\n",  stdout);
+    fputs("(cpu    ) CPU0 started\n", stdout);
 
     /*
     **  Emulation loop.
@@ -341,7 +347,7 @@ void idleThrottle(CpuContext *ctx)
                 {
                 if (ctx->id == 0)
                     {
-                    if (idleCheckBusy() || npuBipIsBusy() || rtcClockIsCurrent == FALSE)
+                    if (idleCheckBusy() || npuBipIsBusy() || (rtcClockIsCurrent == FALSE))
                         {
                         return;
                         }
@@ -467,26 +473,27 @@ bool idleDetectorMACE(CpuContext *ctx)
         {
         return TRUE;
         }
+
     return FALSE;
     }
 
- /*--------------------------------------------------------------------------
- **  Purpose:        Run a helper process.
- **
- **  Parameters:     Name        Description.
- **                  command     Helper command to run
- **
- **  Returns:        0 if successful, error code otherwise.
- **
- **------------------------------------------------------------------------*/
+/*--------------------------------------------------------------------------
+**  Purpose:        Run a helper process.
+**
+**  Parameters:     Name        Description.
+**                  command     Helper command to run
+**
+**  Returns:        0 if successful, error code otherwise.
+**
+**------------------------------------------------------------------------*/
 int runHelper(char *command)
     {
 #if defined (_WIN32)
-    char *dp;
+    char                *dp;
     PROCESS_INFORMATION pi;
-    STARTUPINFO si;
-    char *sp;
-    char winCmdLine[210];
+    STARTUPINFO         si;
+    char                *sp;
+    char                winCmdLine[210];
 
     memset(&si, 0, sizeof(si));
     si.cb = sizeof(si);
@@ -497,20 +504,20 @@ int runHelper(char *command)
     while (*sp != '\0')
         {
         *dp++ = (*sp == '/') ? '\\' : *sp;
-        sp += 1;
+        sp   += 1;
         }
     *dp = '\0';
 
     if (!CreateProcessA("C:\\Windows\\System32\\cmd.exe", // Module name
-        winCmdLine,                // Command line
-        NULL,                      // Process handle not inheritable
-        NULL,                      // Thread handle not inheritable
-        FALSE,                     // Set handle inheritance to FALSE
-        CREATE_NEW_CONSOLE,        // Creation flags
-        NULL,                      // Use parent's environment block
-        NULL,                      // Use parent's starting directory 
-        &si,                       // Pointer to STARTUPINFO structure
-        &pi)                       // Pointer to PROCESS_INFORMATION structure
+                        winCmdLine,                       // Command line
+                        NULL,                             // Process handle not inheritable
+                        NULL,                             // Thread handle not inheritable
+                        FALSE,                            // Set handle inheritance to FALSE
+                        CREATE_NEW_CONSOLE,               // Creation flags
+                        NULL,                             // Use parent's environment block
+                        NULL,                             // Use parent's starting directory
+                        &si,                              // Pointer to STARTUPINFO structure
+                        &pi)                              // Pointer to PROCESS_INFORMATION structure
         )
         {
         return GetLastError();
@@ -558,11 +565,11 @@ void startHelpers(void)
         rc = runHelper(command);
         if (rc == 0)
             {
-            printf("(helper ) Started: %s\n", line);
+            printf("(main   ) Started helper: %s\n", line);
             }
         else
             {
-            printf("(helper ) Failed to start \"%s\", rc = %d\n", line, rc);
+            printf("(main   ) Failed to start helper \"%s\", rc = %d\n", line, rc);
             }
         }
     }
@@ -590,11 +597,11 @@ void stopHelpers(void)
             rc = runHelper(command);
             if (rc == 0)
                 {
-                printf("\n(helper ) Stopped: %s\n", line);
+                printf("\n(main   ) Stopped helper: %s\n", line);
                 }
             else
                 {
-                printf("\n(helper ) Failed to stop \"%s\", rc = %d\n", line, rc);
+                printf("\n(main   ) Failed to stop helper \"%s\", rc = %d\n", line, rc);
                 }
             }
         }
@@ -604,11 +611,11 @@ void stopHelpers(void)
         rc = runHelper(command);
         if (rc == 0)
             {
-            printf("\n(helper ) Stopped: %s\n", networkInterfaceMgr);
+            printf("\n(main   ) Stopped helper: %s\n", networkInterfaceMgr);
             }
         else
             {
-            printf("\n(helper ) Failed to stop \"%s\", rc = %d\n", networkInterfaceMgr, rc);
+            printf("\n(main   ) Failed to stop helper \"%s\", rc = %d\n", networkInterfaceMgr, rc);
             }
         }
     fflush(stdout);
@@ -686,10 +693,13 @@ static void INThandler(int sig)
     char c;
 
     signal(sig, SIG_IGN);
-    printf("\n*WARNING*:===================="
-           "\n*WARNING*: Ctrl-C Intercepted!"
-           "\n*WARNING*:===================="
-           "\nDo you really want to quit? [y/n] ");
+    //  Use Async-safe output function.
+    //                        1 234567890....+....2....+....3..
+    _write(STD_OUTPUT_HANDLE, "\n*WARNING*:=====================", 32);
+    _write(STD_OUTPUT_HANDLE, "\n*WARNING*: Ctrl-C Intercepted! ", 32);
+    _write(STD_OUTPUT_HANDLE, "\n*WARNING*:=====================", 32);
+    //                        1 2 34567890....+....2....+....3....+.
+    _write(STD_OUTPUT_HANDLE, "\n\nDo you really want to quit? [y/n] ", 36);
     c = (char)getchar();
     if ((c == 'y') || (c == 'Y'))
         {
@@ -705,6 +715,7 @@ static void INThandler(int sig)
 static void opExit()
     {
     char check;
+
     timeEndPeriod(8);
     if (_isatty(_fileno(stdin)) && opIsConsoleInput())
         {

--- a/maintenance_channel.c
+++ b/maintenance_channel.c
@@ -485,7 +485,7 @@ static void mchIo(void)
             if (!activeChannel->full)
                 {
                 switch (connCode)
-                {
+                    {
                 default:
                 case FcConnIou:
                     dp = dataIou;
@@ -498,10 +498,10 @@ static void mchIo(void)
                 case FcConnCpu:
                     dp = dataCpu;
                     break;
-                }
+                    }
 
                 switch (mchLocation)
-                {
+                    {
                 case RegAddrElementId:
                 case RegAddrOptionsInstalled:
                     typeCode = 0;
@@ -509,7 +509,7 @@ static void mchIo(void)
 
                 default:
                     break;
-                }
+                    }
 
                 if (activeDevice->recordLength > 0)
                     {
@@ -556,7 +556,7 @@ static void mchIo(void)
             if (activeChannel->full)
                 {
                 switch (connCode)
-                {
+                    {
                 default:
                 case FcConnIou:
                     dp = dataIou;
@@ -569,10 +569,10 @@ static void mchIo(void)
                 case FcConnCpu:
                     dp = dataCpu;
                     break;
-                }
+                    }
 
                 switch (mchLocation)
-                {
+                    {
                 case RegAddrElementId:
                 case RegAddrOptionsInstalled:
                     typeCode = 0;
@@ -580,7 +580,7 @@ static void mchIo(void)
 
                 default:
                     break;
-                }
+                    }
 
                 if (activeDevice->recordLength > 0)
                     {

--- a/mdi.c
+++ b/mdi.c
@@ -46,7 +46,7 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
-#endif 
+#endif
 
 
 #include "const.h"
@@ -353,12 +353,12 @@ void mdiInit(u8 eqNo, u8 unitNo, u8 channelNo, char *deviceName)
         }
 #endif
 
-    /*  
+    /*
     ** set HCP software type, exit if npuSw is not SwUndefined
     */
     if (npuSw != SwUndefined)
         {
-        fprintf(stderr, "(cci_hip) CCP and CCI devices are mutually exclusive\n");
+        logDtError(LogErrorLocation, "CCP and CCI devices are mutually exclusive\n");
         exit(1);
         }
     npuSw = SwCCP;
@@ -380,7 +380,7 @@ void mdiInit(u8 eqNo, u8 unitNo, u8 channelNo, char *deviceName)
     mdi = calloc(1, sizeof(MdiParam));
     if (mdi == NULL)
         {
-        fprintf(stderr, "Failed to allocate mdi context block\n");
+        logDtError(LogErrorLocation, "Failed to allocate mdi context block\n");
         exit(1);
         }
 
@@ -430,8 +430,8 @@ bool mdiHipUplineBlockImpl(NpuBuffer *bp)
         if ((bp != mdi->uplineData)
             || (bp->data[BlkOffCN] != mdi->uplineData->data[BlkOffCN]))
             {
-            fprintf(stderr, "(mdi     ) MDI upline block rejected, CN=%02X, BT=%02X, PDU size=%d\n", bp->data[BlkOffCN],
-                    bp->data[BlkOffBTBSN] & BlkMaskBT, bp->numBytes);
+            logDtError(LogErrorLocation, "MDI upline block rejected, CN=%02X, BT=%02X, PDU size=%d\n", bp->data[BlkOffCN],
+                       bp->data[BlkOffBTBSN] & BlkMaskBT, bp->numBytes);
             mdiPrintStackTrace(stderr);
             }
 #endif

--- a/msufrend.c
+++ b/msufrend.c
@@ -116,15 +116,16 @@
 #define DEFAULT_TCP_PORT                  6500
 #define IoTurnsPerPoll                    4
 #define MIN_FREE_PORT_BUFFERS             2
+
 /*
 ** It appears that the Cyber never tries to access memory beyond this.
 */
 #define MAX_FREND_BYTES                   0xc0000
 
 /* hard-coded port numbers for initial implementation. */
-#define FPORTCONSOLE      4     /* must be greater than PTN.MAX */
-#define RESERVED_PORTS    4
-#define FIRSTUSERPORT     (RESERVED_PORTS+1)
+#define FPORTCONSOLE                      4 /* must be greater than PTN.MAX */
+#define RESERVED_PORTS                    4
+#define FIRSTUSERPORT                     (RESERVED_PORTS + 1)
 
 /*
 **  -----------------------
@@ -132,17 +133,17 @@
 **  -----------------------
 */
 /* Interdata 7/32 types */
-#define ByteAddr  u32
-#define FrendAddr u32
-#define FullWord  u32
-#define HalfWord  u16
+#define ByteAddr     u32
+#define FrendAddr    u32
+#define FullWord     u32
+#define HalfWord     u16
 
 /* Compute FWA of socket entry given port number */
-#define portNumToFwa(portNum) (activeFrend->fwaPORT + (portNum - 1) * LE_PORT)
-#define sockNumToFwa(sockNum) (activeFrend->fwaSOCK + (sockNum - 1) * LE_SOCK)
+#define portNumToFwa(portNum)    (activeFrend->fwaPORT + (portNum - 1) * LE_PORT)
+#define sockNumToFwa(sockNum)    (activeFrend->fwaSOCK + (sockNum - 1) * LE_SOCK)
 
 #if !defined(_WIN32)
-#define SOCKET int
+#define SOCKET    int
 #endif
 
 /*
@@ -166,23 +167,23 @@ typedef enum telnetState
 
 typedef struct pendingBuffer
     {
-    u8    buf[L_LINE + 16];  /* Waiting chars */
-    int   first;             /* Index of first char still pending */
-    int   charsLeft;        /* # of chars remaining in buffer */
+    u8  buf[L_LINE + 16];   /* Waiting chars */
+    int first;              /* Index of first char still pending */
+    int charsLeft;          /* # of chars remaining in buffer */
     } PendingBuffer;
 
 typedef struct portContext
     {
-    int           id;
-    struct frendContext *frend; /* pointer to supporting FREND context */
-    bool          active;       /* TRUE if port is connected and active */
-    SOCKET        fd;           /* TCP socket descriptor */
-    TelnetState   telnetState;  /* telnet state */
-    bool          EOLL;         /* TRUE if last line ended in end of line */
-    PendingBuffer pbuf;         /* chars pending output.  Normally, this is 0 */
-                                /* except when assembling bytes to be sent. */
-                                /* If non-zero, then we shouldn't send any */
-                                /* more lines until this buffer is sent. */
+    int                 id;
+    struct frendContext *frend;      /* pointer to supporting FREND context */
+    bool                active;      /* TRUE if port is connected and active */
+    SOCKET              fd;          /* TCP socket descriptor */
+    TelnetState         telnetState; /* telnet state */
+    bool                EOLL;        /* TRUE if last line ended in end of line */
+    PendingBuffer       pbuf;        /* chars pending output.  Normally, this is 0 */
+                                     /* except when assembling bytes to be sent. */
+                                     /* If non-zero, then we shouldn't send any */
+                                     /* more lines until this buffer is sent. */
     } PortContext;
 
 typedef struct frendContext
@@ -206,21 +207,21 @@ typedef struct frendContext
                                                * but which is not supposed to change the address register. */
     u8                  mem[MAX_FREND_BYTES]; /* Contents of FREND memory, in bytes.
                                                * The 7/32 stored in most-significant-byte-first format */
-    FrendAddr fwaMISC;
-    FrendAddr fwaFPCOM;
-    FrendAddr fwaBF80;
-    FrendAddr fwaBF240;
-    FrendAddr fwaBFREL;
-    FrendAddr fwaBANM;
-    FrendAddr fwaLOGM;
-    FrendAddr fwaSOCK;
-    FrendAddr fwaDVSK;
-    FrendAddr fwaPORT;
-    FrendAddr fwaPTBUF;
-    FrendAddr fwaMALC;
-    FrendAddr fwaALLOC;
-    FrendAddr fwaBuffers80;
-    FrendAddr fwaBuffers240;
+    FrendAddr           fwaMISC;
+    FrendAddr           fwaFPCOM;
+    FrendAddr           fwaBF80;
+    FrendAddr           fwaBF240;
+    FrendAddr           fwaBFREL;
+    FrendAddr           fwaBANM;
+    FrendAddr           fwaLOGM;
+    FrendAddr           fwaSOCK;
+    FrendAddr           fwaDVSK;
+    FrendAddr           fwaPORT;
+    FrendAddr           fwaPTBUF;
+    FrendAddr           fwaMALC;
+    FrendAddr           fwaALLOC;
+    FrendAddr           fwaBuffers80;
+    FrendAddr           fwaBuffers240;
     } FrendContext;
 
 /*
@@ -233,8 +234,10 @@ static FcStatus  msufrendFunc(PpWord funcCode);
 static void      msufrendIo(void);
 static void      msufrendActivate(void);
 static void      msufrendDisconnect(void);
+
 #if DEBUG
 static char      *msufrendFunc2String(PpWord funcCode);
+
 #endif
 
 static void      handleInterruptFromHost(void);
@@ -329,30 +332,30 @@ void msufrendInit(u8 eqNo, u8 unitNo, u8 channelNo, char *params)
         }
     else if (numParam < 2)
         {
-        portCount  = DEFAULT_MAX_CONNECTIONS;
-        isTelnet   = TRUE;
+        portCount = DEFAULT_MAX_CONNECTIONS;
+        isTelnet  = TRUE;
         }
     else if (strcasecmp(connType, "telnet") == 0)
         {
-        isTelnet   = TRUE;
+        isTelnet = TRUE;
         }
     else if (strcasecmp(connType, "raw") == 0)
         {
-        isTelnet   = FALSE;
+        isTelnet = FALSE;
         }
     else
         {
-        fprintf(stderr, "(msufrend) Invalid connection type: %s, not one of 'telnet' or 'raw'.\n", connType);
+        logDtError(LogErrorLocation, "Invalid connection type: %s, not one of 'telnet' or 'raw'.\n", connType);
         exit(1);
         }
     if ((listenPort < 1) || (listenPort > 65535))
         {
-        fprintf(stderr, "(msufrend) Invalid TCP port number: %d\n", listenPort);
+        logDtError(LogErrorLocation, "Invalid TCP port number: %d\n", listenPort);
         exit(1);
         }
     if (portCount < 1)
         {
-        fprintf(stderr, "(msufrend) Invalid port count: %d\n", portCount);
+        logDtError(LogErrorLocation, "Invalid port count: %d\n", portCount);
         exit(1);
         }
     activeFrend = (FrendContext *)calloc(1, sizeof(FrendContext));
@@ -361,7 +364,7 @@ void msufrendInit(u8 eqNo, u8 unitNo, u8 channelNo, char *params)
         fputs("(msufrend) Failed to allocate context block\n", stderr);
         exit(1);
         }
-    dp->context[0]          = activeFrend;
+    dp->context[0] = activeFrend;
     if (firstFrend == NULL)
         {
         firstFrend = activeFrend;
@@ -392,12 +395,12 @@ void msufrendInit(u8 eqNo, u8 unitNo, u8 channelNo, char *params)
     */
     for (i = 0, pp = activeFrend->ports; i < activeFrend->portCount; i++, pp++)
         {
-        pp->id        = i + 1;
-        pp->frend     = activeFrend;
-        pp->active    = FALSE;
-        pp->EOLL      = FALSE;
-        fwaThisSock   = portNumToFwa(pp->id);
-        fwaListSock   = fwaThisSock + W_SKOTCL;
+        pp->id      = i + 1;
+        pp->frend   = activeFrend;
+        pp->active  = FALSE;
+        pp->EOLL    = FALSE;
+        fwaThisSock = portNumToFwa(pp->id);
+        fwaListSock = fwaThisSock + W_SKOTCL;
         /* Initialize the circular list, which is actually part of the socket entry. */
         initCircList(fwaListSock, L_SKOCL);
         setHalfWord(fwaThisSock + H_SKNUM, pp->id);
@@ -416,7 +419,7 @@ void msufrendInit(u8 eqNo, u8 unitNo, u8 channelNo, char *params)
     if (activeFrend->listenFd == -1)
 #endif
         {
-        fprintf(stderr, "(msufrend) Can't create socket on port %d\n", activeFrend->listenPort);
+        logDtError(LogErrorLocation, "Can't create socket on port %d\n", activeFrend->listenPort);
         exit(1);
         }
 
@@ -449,15 +452,15 @@ void msufrendShowStatus()
             {
             sprintf(outBuf, "    >   %-8s C%02o E%02o     ", "MSUFrEnd", fp->channelNo, fp->eqNo);
             opDisplay(outBuf);
-            sprintf(outBuf, FMTNETSTATUS"\n", netGetLocalTcpAddress(fp->listenFd), "", "frend", "listening");
+            sprintf(outBuf, FMTNETSTATUS "\n", netGetLocalTcpAddress(fp->listenFd), "", "frend", "listening");
             opDisplay(outBuf);
             for (i = 0, pp = fp->ports; i < fp->portCount; i++, pp++)
                 {
-                if (pp->active && pp->fd > 0)
+                if (pp->active && (pp->fd > 0))
                     {
-                    sprintf(outBuf, "(msu    )         P%02o ",  pp->id);
+                    sprintf(outBuf, "(msu    )         P%02o ", pp->id);
                     opDisplay(outBuf);
-                    sprintf(outBuf, FMTNETSTATUS"\n", netGetLocalTcpAddress(pp->fd), netGetPeerTcpAddress(pp->fd), "frend", "connected");
+                    sprintf(outBuf, FMTNETSTATUS "\n", netGetLocalTcpAddress(pp->fd), netGetPeerTcpAddress(pp->fd), "frend", "connected");
                     opDisplay(outBuf);
                     }
                 }
@@ -484,7 +487,7 @@ static FcStatus msufrendFunc(PpWord funcCode)
      * more or less.  In some cases, the bottom 8 bits contain data related
      * to the function--typically address bits to set.
      */
-    activeDevice->fcode   = funcCode & 07400;
+    activeDevice->fcode = funcCode & 07400;
 
 #if DEBUG
     fprintf(msufrendLog, "\n%010u PP:%02o CH:%02o P:%04o f:%04o T:%s",
@@ -500,6 +503,7 @@ static FcStatus msufrendFunc(PpWord funcCode)
         if (FcFEFDES == funcCode)
             {
             activeDevice->fcode = funcCode;
+
             return FcProcessed;
             }
 
@@ -517,6 +521,7 @@ static FcStatus msufrendFunc(PpWord funcCode)
 #if DEBUG
         fprintf(msufrendLog, " data:%02x", data);
 #endif
+
         return FcProcessed;
 
     case FcFEFSAM:
@@ -525,6 +530,7 @@ static FcStatus msufrendFunc(PpWord funcCode)
 #if DEBUG
         fprintf(msufrendLog, " data:%02x", data);
 #endif
+
         return FcProcessed;
 
     case FcFEFHL:
@@ -533,12 +539,14 @@ static FcStatus msufrendFunc(PpWord funcCode)
 
     case FcFEFINT: /* Interrupt the 7/32 */
         handleInterruptFromHost();
+
         return FcProcessed;
 
     case FcFEFLP: /* LOAD INTERFACE MEMORY */
         /* Prepare to accept 8-bit bytes, to be written in "a 16-byte memory"
          * starting at location 0. */
         activeFrend->addr = 0;
+
         return FcProcessed;
 
     case FcFEFRM:
@@ -573,7 +581,7 @@ static FcStatus msufrendFunc(PpWord funcCode)
         /* by the PPU with a DCN.  Address register is not changed, says */
         /* the 6CA hardware doc. */
         /* Apparently the top bit is set. */
-        activeFrend->addr = (activeFrend->addr & 0x1fffe00) | ((u32)(data << 1));
+        activeFrend->addr         = (activeFrend->addr & 0x1fffe00) | ((u32)(data << 1));
         activeFrend->nextIsSecond = FALSE;
 #if DEBUG
         fprintf(msufrendLog, " data:%02x addr:%05x <-", data, activeFrend->addr);
@@ -652,7 +660,7 @@ static void msufrendIo(void)
             /* not change the address register. */
             if (activeFrend->nextIsSecond)
                 {
-                activeChannel->data = activeFrend->mem[activeFrend->addr + 1];
+                activeChannel->data       = activeFrend->mem[activeFrend->addr + 1];
                 activeFrend->nextIsSecond = FALSE; /* Probably unnecessary. */
                 }
             else
@@ -660,7 +668,7 @@ static void msufrendIo(void)
                 activeChannel->data = activeFrend->mem[activeFrend->addr];
                 /* Set top bit of word. */
                 activeFrend->mem[activeFrend->addr] |= 0x80;
-                activeFrend->nextIsSecond = TRUE;
+                activeFrend->nextIsSecond            = TRUE;
                 }
             activeChannel->full = TRUE;
 #if DEBUG
@@ -676,8 +684,8 @@ static void msufrendIo(void)
             /*
             **  Output data.
             */
-            activeFrend->mem[activeFrend->addr++] = (u8)activeChannel->data >> 8;
-            activeFrend->mem[activeFrend->addr++] = (u8)activeChannel->data & 0xff;
+            activeFrend->mem[activeFrend->addr++] = (u8)(activeChannel->data >> 8);
+            activeFrend->mem[activeFrend->addr++] = (u8)(activeChannel->data & 0xff);
             activeChannel->full = FALSE;
 #if DEBUG
             fprintf(msufrendLog, " %04o", activeChannel->data);
@@ -838,7 +846,6 @@ static int getLastSocketError()
 #endif
     }
 
-
 /*--- function addrFrendTo1FP ----------------------
  *  Convert an address from FREND to 1FP format.
  *  This means dividing by 2, and ORing in the magic value
@@ -876,10 +883,10 @@ static void setFullWord(FrendAddr addr, FullWord word)
 
 static FullWord getFullWord(FrendAddr addr)
     {
-    return   (activeFrend->mem[addr    ] << 24)
+    return (activeFrend->mem[addr] << 24)
            | (activeFrend->mem[1 + addr] << 16)
            | (activeFrend->mem[2 + addr] << 8)
-           |  activeFrend->mem[3 + addr];
+           | activeFrend->mem[3 + addr];
     }
 
 static void setHalfWord(FrendAddr addr, HalfWord half)
@@ -960,6 +967,7 @@ static int sendToFSock(PortContext *pp, u8 bufout[], int nOutBytes)
 #if DEBUG
             fprintf(msufrendLog, "\nsendToFSock on port %d is not active", pp->id);
 #endif
+
             return -1;
             }
         }
@@ -976,6 +984,7 @@ static int sendToFSock(PortContext *pp, u8 bufout[], int nOutBytes)
 static HalfWord initCircList(FrendAddr fwaList, HalfWord nslots)
     {
     HalfWord totbytes = H_CIRCLIST_HEADER_BYTES + (nslots * CIRCLIST_SLOT_SIZE_BYTES);
+
     memset(activeFrend->mem + fwaList, 0, totbytes);
     setHalfWord(fwaList + H_CIRCLIST_N_SLOTS_TOT, nslots);
 
@@ -1058,6 +1067,7 @@ static void addToTopOfList(FrendAddr fwaList, FullWord myword)
 #if DEBUG
         fprintf(msufrendLog, "\naddToTopOfList(%x, %x): value already in list", fwaList, myword);
 #endif
+
         return;
         }
     if (nSlotsUsed >= nSlotsTot)
@@ -1228,7 +1238,7 @@ static FrendAddr get80()
 
     if (0 == bufAddr)
         {
-        fprintf(stderr, "(msufrend) get80: no free buffers\n");
+        logDtError(LogErrorLocation, "get80: no free buffers\n");
         }
 
     return bufAddr;
@@ -1243,7 +1253,7 @@ static FrendAddr get240()
 
     if (0 == bufAddr)
         {
-        fprintf(stderr, "(msufrend) get240: no free buffers\n");
+        logDtError(LogErrorLocation, "get240: no free buffers\n");
         }
 
     return bufAddr;
@@ -1255,7 +1265,7 @@ static FrendAddr get240()
  */
 static FrendAddr getBufferForC(const char *szmsg)
     {
-    u8 len = strlen(szmsg);
+    u8 len = (u8)strlen(szmsg);
     /* Technically, I should first check len for >80 */
     FrendAddr bufaddr = get80();
 
@@ -1430,7 +1440,7 @@ static void initLmbi()
 
     /* Carve out buffers from the end here and insert them
      * into the 80-char and 240-char buffer circular lists. */
-    nSlots       = getHalfWord(activeFrend->fwaBF80 + H_CIRCLIST_N_SLOTS_TOT);
+    nSlots = getHalfWord(activeFrend->fwaBF80 + H_CIRCLIST_N_SLOTS_TOT);
     activeFrend->fwaBuffers80 = curTableFwa;
     for (islot = 0; islot < nSlots; islot++)
         {
@@ -1438,7 +1448,7 @@ static void initLmbi()
         curTableFwa += LE_BF80;
         }
 
-    nSlots        = getHalfWord(activeFrend->fwaBF240 + H_CIRCLIST_N_SLOTS_TOT);
+    nSlots = getHalfWord(activeFrend->fwaBF240 + H_CIRCLIST_N_SLOTS_TOT);
     activeFrend->fwaBuffers240 = curTableFwa;
     for (islot = 0; islot < nSlots; islot++)
         {
@@ -1523,7 +1533,7 @@ static HalfWord initPortFirstTime(FrendAddr fwaList, HalfWord portNum)
     setPortFullWord(portNum, W_PTINCL, fwaList);
 
     fwaList += nBytes;
-    nBytes += initCircList(fwaList, nOutBufs);
+    nBytes  += initCircList(fwaList, nOutBufs);
     setPortFullWord(portNum, W_PTOTCL, fwaList);
 
     return nBytes;
@@ -1823,7 +1833,7 @@ static FrendAddr GETDATA(PortContext *pp, FrendAddr fwaMySocket)
     {
     FrendAddr bufaddr;
     FrendAddr fwaList = fwaMySocket + W_SKOTCL; /* Not a pointer */
-    u8     charCode = 0xe5, ctlFlags = 0xe5 /*//! debug */;
+    u8        charCode = 0xe5, ctlFlags = 0xe5 /*//! debug */;
 
     pp->EOLL = FALSE;
 
@@ -1893,9 +1903,9 @@ static void sendOTBSIfNecessary(HalfWord portNum, FrendAddr fwaMyPort, bool bIsE
     {
     /* Don't send an OTBS unless either CHTHRSH says to,
      * or PTOTBS is set.  */
-    bool  bSendOTBS   = FALSE;
-    bool  bBelowThres = CKTHRSH(fwaMyPort);
-    u8 MsgCode     = FP_OTBS;
+    bool bSendOTBS   = FALSE;
+    bool bBelowThres = CKTHRSH(fwaMyPort);
+    u8   MsgCode     = FP_OTBS;
 
     INTRLOC(fwaMyPort + H_PTNDIK);
     if (!HFLAGISSET(fwaMyPort, PTOTBS) || bBelowThres)
@@ -1948,7 +1958,10 @@ static void taskSKOTCL(PortContext *pp, FrendAddr fwaMySocket)
     {
     FrendAddr bufaddr;
 
-    if (pp == NULL) return;
+    if (pp == NULL)
+        {
+        return;
+        }
 
     /* If there are pending output characters, don't send more lines. */
     if (CHKACT(pp, fwaMySocket) == FALSE)
@@ -1966,8 +1979,8 @@ static void taskSKOTCL(PortContext *pp, FrendAddr fwaMySocket)
             }
         if ((FP_FECNE == recType) || (FP_FEC == recType))
             {
-            char  buf[256];
-            u8 len = getByte(bufaddr + C_DHBCT) - L_DTAHDR;
+            char buf[256];
+            u8   len = getByte(bufaddr + C_DHBCT) - L_DTAHDR;
             memcpy(buf, &activeFrend->mem[bufaddr + L_DTAHDR], len);
             buf[len] = '\0';
             /* //! Should we call PUTBUF with bufaddr here? */
@@ -2105,10 +2118,10 @@ static void taskSENDCP(HalfWord portNum, u8 MsgCode)
     {
     /*//! I'm not sure I'm handling V_EXTREQ right.
      * I am basically ignoring it. */
-    u8     MsgCodeWithoutFlag = (u8)(MsgCode & (0xff ^ V_EXTREQ));
-    FrendAddr fwaMyPort = portNumToFwa(portNum);
-    HalfWord  ctlPort   = getHalfWord(fwaMyPort + H_PTCPN);
-    FrendAddr bufaddr   = get80();
+    u8        MsgCodeWithoutFlag = (u8)(MsgCode & (0xff ^ V_EXTREQ));
+    FrendAddr fwaMyPort          = portNumToFwa(portNum);
+    HalfWord  ctlPort            = getHalfWord(fwaMyPort + H_PTCPN);
+    FrendAddr bufaddr            = get80();
 
     /* Set the message code, clearing the V_EXTREQ bit. */
     setByte(bufaddr + C_DHTYPE, MsgCodeWithoutFlag);
@@ -2371,7 +2384,7 @@ static void taskCLOFSK(HalfWord socketNum, FrendAddr fwaMySocket)
  *  it ignores the second connection in the socket.
  */
 static void CLRPTS(HalfWord portNum, FrendAddr fwaMyPort,
-            HalfWord socketNum, FrendAddr fwaMySocket)
+                   HalfWord socketNum, FrendAddr fwaMySocket)
     {
     setHalfWord(fwaMySocket + H_SKCN1, 0);
     setByte(fwaMySocket + C_SKCT1, 0);
@@ -2705,7 +2718,7 @@ static void PALISR(PortContext *pp, u8 ch)
     FrendAddr bufout      = 0;
     HalfWord  count;
     /* Echo characters if "suppress echo" is not set. */
-    bool doEcho           = !HFLAGISSET(fwaMySocket, SKSUPE);
+    bool doEcho = !HFLAGISSET(fwaMySocket, SKSUPE);
 
     if (0 == bufaddr)
         {
@@ -2761,7 +2774,7 @@ static void PALISR(PortContext *pp, u8 ch)
         doEcho = FALSE;
         break;
 
-    case '\x1b': /* Escape: abort current program and discard input line */
+    case '\x1b':                         /* Escape: abort current program and discard input line */
         doEcho = FALSE;
         CLEARHFLAG(fwaMySocket, SKSUPE); /* CLEAR 'SUPPRESS ECHO' FLAG */
         if (!HFLAGISSET(fwaMySocket, SKESCP))
@@ -2883,7 +2896,7 @@ static void cmdHereIs(HalfWord portNum, int offsetForBufType)
 
     cmdPort = getHalfWord(activeFrend->fwaFPCOM + H_FCMDPT);
 #if DEBUG
-        fprintf(msufrendLog, " cmdPort:%04x", cmdPort);
+    fprintf(msufrendLog, " cmdPort:%04x", cmdPort);
 #endif
 
     if (cmdPort <= PTN_MAX)
@@ -3012,32 +3025,36 @@ static void handleInterruptFromHost()
  *  select() noticed an incoming connection on the listening port.
  *  Accept it and create a new terminal session.
  */
-static u8 telnetIntro[] = {
+static u8 telnetIntro[] =
+    {
     TELCODE_IAC, TELCODE_DONT, TELCODE_OPT_ECHO,
     TELCODE_IAC, TELCODE_WILL, TELCODE_OPT_ECHO,
     TELCODE_IAC, TELCODE_WILL, TELCODE_OPT_SUPPRESS_GO_AHEAD,
-    TELCODE_IAC, TELCODE_DO, TELCODE_OPT_SUPPRESS_GO_AHEAD
-};
+    TELCODE_IAC, TELCODE_DO,   TELCODE_OPT_SUPPRESS_GO_AHEAD
+    };
 
 static void processIncomingConnection()
     {
 #if defined(_WIN32)
     u_long blockEnable = 1;
 #endif
-    SOCKET fd;
+    SOCKET             fd;
     struct sockaddr_in from;
 #if defined(_WIN32)
     int fromLen;
 #else
     socklen_t fromLen;
 #endif
-    int            i;
-    int            optEnable = 1;
-    PortContext    *pp;
+    int         i;
+    int         optEnable = 1;
+    PortContext *pp;
 
     fromLen = sizeof(from);
-    fd = accept(activeFrend->listenFd, (struct sockaddr *)&from, &fromLen);
-    if (fd < 0) return;
+    fd      = accept(activeFrend->listenFd, (struct sockaddr *)&from, &fromLen);
+    if (fd < 0)
+        {
+        return;
+        }
 
     /*
     **  Set Keepalive option so that we can eventually discover if
@@ -3063,9 +3080,9 @@ static void processIncomingConnection()
         {
         if (pp->active == FALSE)
             {
-            pp->active = TRUE;
+            pp->active      = TRUE;
             pp->telnetState = TELST_NORMAL;
-            pp->fd = fd;
+            pp->fd          = fd;
             break;
             }
         }
@@ -3081,7 +3098,7 @@ static void processIncomingConnection()
     else
         {
         char *sorry = "\r\nSorry, all sockets are in use. Please try again later.";
-        int n = send(fd, (unsigned char *)sorry, strlen(sorry), 0);
+        int  n      = send(fd, (unsigned char *)sorry, (int)strlen(sorry), 0);
         netCloseConnection(fd);
         }
     }
@@ -3095,8 +3112,8 @@ static void processIncomingConnection()
  */
 static void processInboundTelnet(PortContext *pp, unsigned char *buf, int len)
     {
-    int     i;
-    u8      ch;
+    int i;
+    u8  ch;
 
     for (i = 0; i < len; i++)
         {
@@ -3104,7 +3121,7 @@ static void processInboundTelnet(PortContext *pp, unsigned char *buf, int len)
         switch (pp->telnetState)
             {
         case TELST_NORMAL:
-            if (activeFrend->doesTelnet && TELCODE_IAC == ch)
+            if (activeFrend->doesTelnet && (TELCODE_IAC == ch))
                 {
                 pp->telnetState = TELST_GOT_IAC;
                 }
@@ -3143,8 +3160,8 @@ static void processInboundTelnet(PortContext *pp, unsigned char *buf, int len)
  */
 static void writeNowAvailable(PortContext *pp)
     {
-    int           bytesSent;
-    int           nOutBytes = pp->pbuf.charsLeft;
+    int bytesSent;
+    int nOutBytes = pp->pbuf.charsLeft;
 
     bytesSent = sendToFSock(pp, pp->pbuf.buf + pp->pbuf.first, nOutBytes);
     if (bytesSent <= 0)
@@ -3191,7 +3208,7 @@ static void msufrendCheckIo()
     FD_ZERO(&writeFds);
 
     FD_SET(activeFrend->listenFd, &readFds);
-    maxFd = activeFrend->listenFd;
+    maxFd = (int)activeFrend->listenFd;
 
     for (i = FIRSTUSERPORT, pp = activeFrend->ports + (FIRSTUSERPORT - 1); i <= activeFrend->portCount; i++, pp++)
         {
@@ -3212,8 +3229,12 @@ static void msufrendCheckIo()
             if (getListFreeEntries(fwaList) > MIN_FREE_PORT_BUFFERS)
                 {
                 FD_SET(pp->fd, &readFds);
-                if (pp->fd > maxFd) maxFd = pp->fd;
+                if ((int)pp->fd > maxFd)
+                    {
+                    maxFd = (int)pp->fd;
+                    }
                 }
+
             /*
              * If there are characters pending output on this socket,
              * then we need to hear about write availability.
@@ -3221,7 +3242,10 @@ static void msufrendCheckIo()
             if (pp->pbuf.charsLeft > 0)
                 {
                 FD_SET(pp->fd, &writeFds);
-                if (pp->fd > maxFd) maxFd = pp->fd;
+                if ((int)pp->fd > maxFd)
+                    {
+                    maxFd = (int)pp->fd;
+                    }
                 }
             }
         }
@@ -3261,7 +3285,7 @@ static void msufrendCheckIo()
         }
     else if (n < 0)
         {
-        fprintf(stderr, "(msufrend) Error %d from select\n", getLastSocketError());
+        logDtError(LogErrorLocation, "Error %d from select\n", getLastSocketError());
         sleepMsec(500);
         }
     dropInterlock(activeFrend->fwaFPCOM + H_FEDEAD); /* Clear "front-end dead" flag */
@@ -3284,21 +3308,48 @@ static char *msufrendFunc2String(PpWord funcCode)
 
     switch (funcCode)
         {
-    case FcFEFSEL: return "SELECT      ";
-    case FcFEFDES: return "DESELECT    ";
-    case FcFEFST:  return "STATUS      ";
-    case FcFEFSAU: return "SET UPPER   ";
-    case FcFEFSAM: return "SET MIDDLE  ";
-    case FcFEFHL:  return "HALT-LOAD   ";
-    case FcFEFINT: return "INTERRUPT   ";
-    case FcFEFLP:  return "LOAD IFC MEM";
-    case FcFEFRM:  return "READ        ";
-    case FcFEFWM0: return "WRITE MODE 0";
-    case FcFEFWM:  return "WRITE MODE 1";
-    case FcFEFRSM: return "READ AND SET";
-    case FcFEFCI:  return "CLEAR INITIALIZED STATUS BIT";
+    case FcFEFSEL:
+        return "SELECT      ";
+
+    case FcFEFDES:
+        return "DESELECT    ";
+
+    case FcFEFST:
+        return "STATUS      ";
+
+    case FcFEFSAU:
+        return "SET UPPER   ";
+
+    case FcFEFSAM:
+        return "SET MIDDLE  ";
+
+    case FcFEFHL:
+        return "HALT-LOAD   ";
+
+    case FcFEFINT:
+        return "INTERRUPT   ";
+
+    case FcFEFLP:
+        return "LOAD IFC MEM";
+
+    case FcFEFRM:
+        return "READ        ";
+
+    case FcFEFWM0:
+        return "WRITE MODE 0";
+
+    case FcFEFWM:
+        return "WRITE MODE 1";
+
+    case FcFEFRSM:
+        return "READ AND SET";
+
+    case FcFEFCI:
+        return "CLEAR INITIALIZED STATUS BIT";
+
     default:
-        sprintf(buf,      "UNKNOWN %04o", funcCode);
+        sprintf(buf, "UNKNOWN %04o", funcCode);
+
         return buf;
         }
     }

--- a/mt669.c
+++ b/mt669.c
@@ -1951,7 +1951,7 @@ static void mt669Disconnect(void)
         recLen0 = (recLen2 / 4) * 6;
 
         switch (recLen2 % 4)
-        {
+            {
         case 1:
             recLen0 += oddFrameCount ? 1 : 0;
             break;
@@ -1970,7 +1970,7 @@ static void mt669Disconnect(void)
                 recLen0 -= 1;
                 }
             break;
-        }
+            }
 
         break;
 

--- a/mt669.c
+++ b/mt669.c
@@ -404,7 +404,7 @@ void mt669Init(u8 eqNo, u8 unitNo, u8 channelNo, char *deviceName)
                 cp->convFileHandle = fopen(fileName, "w+b");
                 if (cp->convFileHandle == NULL)
                     {
-                    fprintf(stderr, "(mt669  ) Failed to create MT669 backing file\n");
+                    logDtError(LogErrorLocation, "Failed to create MT669 backing file\n");
                     exit(1);
                     }
                 }
@@ -417,7 +417,7 @@ void mt669Init(u8 eqNo, u8 unitNo, u8 channelNo, char *deviceName)
     tp = calloc(1, sizeof(TapeParam));
     if (tp == NULL)
         {
-        fprintf(stderr, "(mt669  ) Failed to allocate MT669 context block\n");
+        logDtError(LogErrorLocation, "Failed to allocate MT669 context block\n");
         exit(1);
         }
 
@@ -446,7 +446,7 @@ void mt669Init(u8 eqNo, u8 unitNo, u8 channelNo, char *deviceName)
         fcb = fopen(deviceName, "rb");
         if (fcb == NULL)
             {
-            fprintf(stderr, "(mt669  ) Failed to open %s\n", deviceName);
+            logDtError(LogErrorLocation, "Failed to open %s\n", deviceName);
             exit(1);
             }
 
@@ -502,7 +502,7 @@ void mt669Terminate(DevSlot *dp)
         if ((fwrite(cp->writeConv, 1, sizeof(cp->writeConv), cp->convFileHandle) != sizeof(cp->writeConv))
             || (fwrite(cp->readConv, 1, sizeof(cp->readConv), cp->convFileHandle) != sizeof(cp->readConv)))
             {
-            fprintf(stderr, "(mt669  ) Error writing MT669 backing file\n");
+            logDtError(LogErrorLocation, "Error writing MT669 backing file\n");
             }
 
         fclose(cp->convFileHandle);
@@ -592,6 +592,7 @@ void mt669LoadTape(char *params)
         {
         sprintf(outBuf, "(mt669  ) Unit %d not allocated\n", unitNo);
         opDisplay(outBuf);
+
         return;
         }
 
@@ -602,6 +603,7 @@ void mt669LoadTape(char *params)
         {
         sprintf(outBuf, "(mt669  ) Unit %d not unloaded\n", unitNo);
         opDisplay(outBuf);
+
         return;
         }
 
@@ -630,6 +632,7 @@ void mt669LoadTape(char *params)
         {
         sprintf(outBuf, "(mt669  ) Failed to open %s\n", str);
         opDisplay(outBuf);
+
         return;
         }
 
@@ -715,6 +718,7 @@ void mt669UnloadTape(char *params)
         {
         sprintf(outBuf, "(mt669  ) Unit %d not allocated\n", unitNo);
         opDisplay(outBuf);
+
         return;
         }
 
@@ -725,6 +729,7 @@ void mt669UnloadTape(char *params)
         {
         sprintf(outBuf, "(mt669  ) Unit %d not loaded\n", unitNo);
         opDisplay(outBuf);
+
         return;
         }
 
@@ -766,7 +771,7 @@ void mt669UnloadTape(char *params)
 void mt669ShowTapeStatus()
     {
     TapeParam *tp = firstTape;
-    char      outBuf[MaxFSPath+128];
+    char      outBuf[MaxFSPath + 128];
 
     while (tp)
         {
@@ -1229,7 +1234,7 @@ static FcStatus mt669Func(PpWord funcCode)
 
     case Fc669CtrlForespaceFindGap:
     case Fc669CtrlBackspaceFindGap:
-        logError(LogErrorLocation, "(mt669  ) channel %02o - unsupported function: %04o", activeChannel->id, (u32)funcCode);
+        logDtError(LogErrorLocation, "Channel %02o - unsupported function: %04o", activeChannel->id, (u32)funcCode);
 
         return (FcProcessed);
 
@@ -1283,14 +1288,14 @@ static FcStatus mt669Func(PpWord funcCode)
         if ((unitNo != -1) && tp->unitReady && tp->ringIn)
             {
             // ? would be nice to truncate somehow
-            logError(LogErrorLocation, "(mt669  ) channel %02o - unsupported function: %04o", activeChannel->id, (u32)funcCode);
+            logDtError(LogErrorLocation, "Channel %02o - unsupported function: %04o", activeChannel->id, (u32)funcCode);
             }
 
         return (FcProcessed);
 
     case Fc669CtrledForespace:
     case Fc669CtrledBackspace:
-        logError(LogErrorLocation, "(mt669  ) channel %02o - unsupported function: %04o", activeChannel->id, (u32)funcCode);
+        logDtError(LogErrorLocation, "Channel %02o - unsupported function: %04o", activeChannel->id, (u32)funcCode);
 
         return (FcProcessed);
 
@@ -1386,7 +1391,7 @@ static FcStatus mt669Func(PpWord funcCode)
     case Fc669OppParity:
     case Fc669OppDensity:
         mt669ResetStatus(tp);
-        logError(LogErrorLocation, "(mt669  ) channel %02o - unsupported function: %04o", activeChannel->id, (u32)funcCode);
+        logDtError(LogErrorLocation, "Channel %02o - unsupported function: %04o", activeChannel->id, (u32)funcCode);
 
         return (FcProcessed);
 
@@ -1401,7 +1406,7 @@ static FcStatus mt669Func(PpWord funcCode)
     case Fc669RereadBkwOddLenParity:
     case Fc669RepeatRead:
         mt669ResetStatus(tp);
-        logError(LogErrorLocation, "(mt669  ) channel %02o - unsupported function: %04o", activeChannel->id, (u32)funcCode);
+        logDtError(LogErrorLocation, "Channel %02o - unsupported function: %04o", activeChannel->id, (u32)funcCode);
 
         return (FcProcessed);
 
@@ -1416,7 +1421,7 @@ static FcStatus mt669Func(PpWord funcCode)
     case Fc669EraseRepos:
     case Fc669EraseEraseRepos:
         mt669ResetStatus(tp);
-        logError(LogErrorLocation, "(mt669  ) channel %02o - unsupported function: %04o", activeChannel->id, (u32)funcCode);
+        logDtError(LogErrorLocation, "Channel %02o - unsupported function: %04o", activeChannel->id, (u32)funcCode);
 
         return (FcProcessed);
 
@@ -1429,7 +1434,7 @@ static FcStatus mt669Func(PpWord funcCode)
     case Fc669CopyReadRam:
     case Fc669CopyWriteRam:
         mt669ResetStatus(tp);
-        logError(LogErrorLocation, "(mt669  ) channel %02o - unsupported function: %04o", activeChannel->id, (u32)funcCode);
+        logDtError(LogErrorLocation, "Channel %02o - unsupported function: %04o", activeChannel->id, (u32)funcCode);
 
         return (FcProcessed);
 
@@ -1442,7 +1447,7 @@ static FcStatus mt669Func(PpWord funcCode)
     case Fc669SendTcuCmd:
     case Fc669SetQuartReadSprktDly:
         mt669ResetStatus(tp);
-        logError(LogErrorLocation, "(mt669  ) channel %02o - unsupported function: %04o", activeChannel->id, (u32)funcCode);
+        logDtError(LogErrorLocation, "Channel %02o - unsupported function: %04o", activeChannel->id, (u32)funcCode);
 
         return (FcProcessed);
 
@@ -1462,7 +1467,7 @@ static FcStatus mt669Func(PpWord funcCode)
         if ((tp == NULL) || !tp->unitReady)
             {
             activeDevice->selectedUnit = -1;
-            logError(LogErrorLocation, "(mt669  ) channel %02o - invalid select: %04o", activeChannel->id, (u32)funcCode);
+            logDtError(LogErrorLocation, "Channel %02o - invalid select: %04o", activeChannel->id, (u32)funcCode);
 
             return (FcDeclined);
             }
@@ -1547,11 +1552,11 @@ static void mt669Io(void)
     switch (activeDevice->fcode)
         {
     default:
-        logError(LogErrorLocation, "(mt669  ) channel %02o - unsupported function code: %04o",
-                 activeChannel->id, activeDevice->fcode);
+        logDtError(LogErrorLocation, "Channel %02o - unsupported function code: %04o",
+                   activeChannel->id, activeDevice->fcode);
         break;
 
-    case 0:
+    case Fc669ClearUnit:
         /*
         **  Previous function has terminated.
         */
@@ -1985,7 +1990,7 @@ static void mt669Disconnect(void)
             ip   += 1;
             }
 
-        recLen0 = rp - rawBuffer;
+        recLen0 = (u32)(rp - rawBuffer);
         if (oddFrameCount)
             {
             recLen0 -= 1;
@@ -2138,7 +2143,7 @@ static void mt669PackAndConvert(u32 recLen)
                 }
             }
 
-        activeDevice->recordLength = op - tp->ioBuffer;
+        activeDevice->recordLength = (PpWord)(op - tp->ioBuffer);
 
         if (tp->oddCount)
             {
@@ -2180,7 +2185,7 @@ static void mt669FuncRead(void)
     /*
     **  Read and verify TAP record length header.
     */
-    len = fread(&recLen0, sizeof(recLen0), 1, activeDevice->fcb[unitNo]);
+    len = (u32)fread(&recLen0, sizeof(recLen0), 1, activeDevice->fcb[unitNo]);
 
     if (len != 1)
         {
@@ -2217,7 +2222,7 @@ static void mt669FuncRead(void)
     */
     if (recLen1 > MaxByteBuf)
         {
-        logError(LogErrorLocation, "channel %02o - tape record too long: %d", activeChannel->id, recLen1);
+        logDtError(LogErrorLocation, "Channel %02o - tape record too long: %d", activeChannel->id, recLen1);
         tp->alert     = TRUE;
         tp->errorCode = EcMiscUnitError;
 
@@ -2242,11 +2247,11 @@ static void mt669FuncRead(void)
     /*
     **  Read and verify the actual raw data.
     */
-    len = fread(rawBuffer, 1, recLen1, activeDevice->fcb[unitNo]);
+    len = (u32)fread(rawBuffer, 1, recLen1, activeDevice->fcb[unitNo]);
 
     if (recLen1 != (u32)len)
         {
-        logError(LogErrorLocation, "(mt669  ) channel %02o - short tape record read: %d", activeChannel->id, len);
+        logDtError(LogErrorLocation, "Channel %02o - short tape record read: %d", activeChannel->id, len);
         tp->alert     = TRUE;
         tp->errorCode = EcMiscUnitError;
 
@@ -2256,11 +2261,11 @@ static void mt669FuncRead(void)
     /*
     **  Read and verify the TAP record length trailer.
     */
-    len = fread(&recLen2, sizeof(recLen2), 1, activeDevice->fcb[unitNo]);
+    len = (u32)fread(&recLen2, sizeof(recLen2), 1, activeDevice->fcb[unitNo]);
 
     if (len != 1)
         {
-        logError(LogErrorLocation, "(mt669  ) channel %02o - missing tape record trailer", activeChannel->id);
+        logDtError(LogErrorLocation, "Channel %02o - missing tape record trailer", activeChannel->id);
         tp->alert     = TRUE;
         tp->errorCode = EcMiscUnitError;
 
@@ -2288,7 +2293,7 @@ static void mt669FuncRead(void)
             }
         else
             {
-            logError(LogErrorLocation, "(mt669  ) channel %02o - invalid tape record trailer: %d", activeChannel->id, recLen2);
+            logDtError(LogErrorLocation, "Channel %02o - invalid tape record trailer: %d", activeChannel->id, recLen2);
             tp->alert     = TRUE;
             tp->errorCode = EcMiscUnitError;
 
@@ -2356,12 +2361,12 @@ static void mt669FuncReadBkw(void)
     **  record trailer).
     */
     fseek(activeDevice->fcb[unitNo], -4, SEEK_CUR);
-    len = fread(&recLen0, sizeof(recLen0), 1, activeDevice->fcb[unitNo]);
+    len = (u32)fread(&recLen0, sizeof(recLen0), 1, activeDevice->fcb[unitNo]);
     fseek(activeDevice->fcb[unitNo], -4, SEEK_CUR);
 
     if (len != 1)
         {
-        logError(LogErrorLocation, "(mt669  ) channel %02o - missing tape record trailer", activeChannel->id);
+        logDtError(LogErrorLocation, "Channel %02o - missing tape record trailer", activeChannel->id);
         tp->alert     = TRUE;
         tp->errorCode = EcMiscUnitError;
 
@@ -2385,7 +2390,7 @@ static void mt669FuncReadBkw(void)
     */
     if (recLen1 > MaxByteBuf)
         {
-        logError(LogErrorLocation, "(mt669  ) channel %02o - tape record too long: %d", activeChannel->id, recLen1);
+        logDtError(LogErrorLocation, "Channel %02o - tape record too long: %d", activeChannel->id, recLen1);
         tp->alert     = TRUE;
         tp->errorCode = EcMiscUnitError;
 
@@ -2404,11 +2409,11 @@ static void mt669FuncReadBkw(void)
         /*
         **  Read and verify the TAP record header.
         */
-        len = fread(&recLen2, sizeof(recLen2), 1, activeDevice->fcb[unitNo]);
+        len = (u32)fread(&recLen2, sizeof(recLen2), 1, activeDevice->fcb[unitNo]);
 
         if (len != 1)
             {
-            logError(LogErrorLocation, "(mt669  ) channel %02o - missing TAP record header", activeChannel->id);
+            logDtError(LogErrorLocation, "Channel %02o - missing TAP record header", activeChannel->id);
             tp->alert     = TRUE;
             tp->errorCode = EcMiscUnitError;
 
@@ -2422,11 +2427,11 @@ static void mt669FuncReadBkw(void)
             */
             position -= 1;
             fseek(activeDevice->fcb[unitNo], position, SEEK_SET);
-            len = fread(&recLen2, sizeof(recLen2), 1, activeDevice->fcb[unitNo]);
+            len = (u32)fread(&recLen2, sizeof(recLen2), 1, activeDevice->fcb[unitNo]);
 
             if ((len != 1) || (recLen0 != recLen2))
                 {
-                logError(LogErrorLocation, "(mt669  ) channel %02o - invalid record length2: %d %08X != %08X", activeChannel->id, len, recLen0, recLen2);
+                logDtError(LogErrorLocation, "Channel %02o - invalid record length2: %d %08X != %08X", activeChannel->id, len, recLen0, recLen2);
                 tp->alert     = TRUE;
                 tp->errorCode = EcMiscUnitError;
 
@@ -2437,11 +2442,11 @@ static void mt669FuncReadBkw(void)
         /*
         **  Read and verify the actual raw data.
         */
-        len = fread(rawBuffer, 1, recLen1, activeDevice->fcb[unitNo]);
+        len = (u32)fread(rawBuffer, 1, recLen1, activeDevice->fcb[unitNo]);
 
         if (recLen1 != (u32)len)
             {
-            logError(LogErrorLocation, "(mt669  ) channel %02o - short tape record read: %d", activeChannel->id, len);
+            logDtError(LogErrorLocation, "Channel %02o - short tape record read: %d", activeChannel->id, len);
             tp->alert     = TRUE;
             tp->errorCode = EcMiscUnitError;
 
@@ -2524,7 +2529,7 @@ static void mt669FuncForespace(void)
     /*
     **  Read and verify TAP record length header.
     */
-    len = fread(&recLen0, sizeof(recLen0), 1, activeDevice->fcb[unitNo]);
+    len = (u32)fread(&recLen0, sizeof(recLen0), 1, activeDevice->fcb[unitNo]);
 
     if (len != 1)
         {
@@ -2561,7 +2566,7 @@ static void mt669FuncForespace(void)
     */
     if (recLen1 > MaxByteBuf)
         {
-        logError(LogErrorLocation, "(mt669  ) channel %02o - tape record too long: %d", activeChannel->id, recLen1);
+        logDtError(LogErrorLocation, "Channel %02o - tape record too long: %d", activeChannel->id, recLen1);
         tp->alert     = TRUE;
         tp->errorCode = EcMiscUnitError;
 
@@ -2588,7 +2593,7 @@ static void mt669FuncForespace(void)
     */
     if (fseek(activeDevice->fcb[unitNo], recLen1, SEEK_CUR) != 0)
         {
-        logError(LogErrorLocation, "(mt669  ) channel %02o - short tape record read: %d", activeChannel->id, len);
+        logDtError(LogErrorLocation, "Channel %02o - short tape record read: %d", activeChannel->id, len);
         tp->alert     = TRUE;
         tp->errorCode = EcMiscUnitError;
 
@@ -2598,11 +2603,11 @@ static void mt669FuncForespace(void)
     /*
     **  Read and verify the TAP record length trailer.
     */
-    len = fread(&recLen2, sizeof(recLen2), 1, activeDevice->fcb[unitNo]);
+    len = (u32)fread(&recLen2, sizeof(recLen2), 1, activeDevice->fcb[unitNo]);
 
     if (len != 1)
         {
-        logError(LogErrorLocation, "(mt669  ) channel %02o - missing tape record trailer", activeChannel->id);
+        logDtError(LogErrorLocation, "Channel %02o - missing tape record trailer", activeChannel->id);
         tp->alert     = TRUE;
         tp->errorCode = EcMiscUnitError;
 
@@ -2630,7 +2635,7 @@ static void mt669FuncForespace(void)
             }
         else
             {
-            logError(LogErrorLocation, "(mt669  ) channel %02o - invalid tape record trailer: %d", activeChannel->id, recLen2);
+            logDtError(LogErrorLocation, "Channel %02o - invalid tape record trailer: %d", activeChannel->id, recLen2);
             tp->alert     = TRUE;
             tp->errorCode = EcMiscUnitError;
 
@@ -2679,12 +2684,12 @@ static void mt669FuncBackspace(void)
     **  record trailer).
     */
     fseek(activeDevice->fcb[unitNo], -4, SEEK_CUR);
-    len = fread(&recLen0, sizeof(recLen0), 1, activeDevice->fcb[unitNo]);
+    len = (u32)fread(&recLen0, sizeof(recLen0), 1, activeDevice->fcb[unitNo]);
     fseek(activeDevice->fcb[unitNo], -4, SEEK_CUR);
 
     if (len != 1)
         {
-        logError(LogErrorLocation, "(mt669  ) channel %02o - missing tape record trailer", activeChannel->id);
+        logDtError(LogErrorLocation, "Channel %02o - missing tape record trailer", activeChannel->id);
         tp->alert     = TRUE;
         tp->errorCode = EcMiscUnitError;
 
@@ -2708,7 +2713,7 @@ static void mt669FuncBackspace(void)
     */
     if (recLen1 > MaxByteBuf)
         {
-        logError(LogErrorLocation, "(mt669  ) channel %02o - tape record too long: %d", activeChannel->id, recLen1);
+        logDtError(LogErrorLocation, "Channel %02o - tape record too long: %d", activeChannel->id, recLen1);
         tp->alert     = TRUE;
         tp->errorCode = EcMiscUnitError;
 
@@ -2727,11 +2732,11 @@ static void mt669FuncBackspace(void)
         /*
         **  Read and verify the TAP record header.
         */
-        len = fread(&recLen2, sizeof(recLen2), 1, activeDevice->fcb[unitNo]);
+        len = (u32)fread(&recLen2, sizeof(recLen2), 1, activeDevice->fcb[unitNo]);
 
         if (len != 1)
             {
-            logError(LogErrorLocation, "(mt669  ) channel %02o - missing TAP record header", activeChannel->id);
+            logDtError(LogErrorLocation, "Channel %02o - missing TAP record header", activeChannel->id);
             tp->alert     = TRUE;
             tp->errorCode = EcMiscUnitError;
 
@@ -2745,11 +2750,11 @@ static void mt669FuncBackspace(void)
             */
             position -= 1;
             fseek(activeDevice->fcb[unitNo], position, SEEK_SET);
-            len = fread(&recLen2, sizeof(recLen2), 1, activeDevice->fcb[unitNo]);
+            len = (u32)fread(&recLen2, sizeof(recLen2), 1, activeDevice->fcb[unitNo]);
 
             if ((len != 1) || (recLen0 != recLen2))
                 {
-                logError(LogErrorLocation, "(mt669  ) channel %02o - invalid record length2: %d %08X != %08X", activeChannel->id, len, recLen0, recLen2);
+                logDtError(LogErrorLocation, "Channel %02o - invalid record length2: %d %08X != %08X", activeChannel->id, len, recLen0, recLen2);
                 tp->alert     = TRUE;
                 tp->errorCode = EcMiscUnitError;
 

--- a/mt679.c
+++ b/mt679.c
@@ -2087,7 +2087,7 @@ static void mt679PackAndConvert(u32 recLen)
         activeDevice->recordLength = (PpWord)(op - tp->ioBuffer);
 
         switch (recLen % 3)
-        {
+            {
         default:
             break;
 
@@ -2098,7 +2098,7 @@ static void mt679PackAndConvert(u32 recLen)
         case 2:
             tp->characterFill = TRUE;
             break;
-        }
+            }
         break;
 
     case 1:

--- a/mux6676.c
+++ b/mux6676.c
@@ -664,7 +664,7 @@ static void mux667xIo(void)
                     **  Port with active TCP connection.
                     */
                     switch (function)
-                    {
+                        {
                     case 2:
                     case 3:
                         if (pp->mux->type == DtMux6671)
@@ -728,7 +728,7 @@ static void mux667xIo(void)
 
                     default:
                         break;
-                    }
+                        }
                     }
                 else if ((pp->mux->type == DtMux6671) && (function == 7))
                     {

--- a/net_util.c
+++ b/net_util.c
@@ -54,7 +54,7 @@
 **  Private Constants
 **  -----------------
 */
-#define MaxListenBacklog 100
+#define MaxListenBacklog    100
 
 /*
 **  -----------------------
@@ -114,10 +114,12 @@ SOCKET netAcceptConnection(SOCKET sd)
     acceptFd = accept(sd, (struct sockaddr *)&from, &fromLen);
     if (acceptFd == INVALID_SOCKET)
         {
-        fprintf(stderr, "(net_util) accept failed, rc=%d\n", WSAGetLastError());
+        logDtError(LogErrorLocation, "(net_util) accept failed, rc=%d\n", WSAGetLastError());
         }
+
     return acceptFd;
     }
+
 #else
 int netAcceptConnection(int sd)
     {
@@ -131,8 +133,10 @@ int netAcceptConnection(int sd)
         {
         perror("(net_util) accept");
         }
+
     return acceptFd;
     }
+
 #endif
 
 /*--------------------------------------------------------------------------
@@ -149,11 +153,13 @@ void netCloseConnection(SOCKET sd)
     {
     closesocket(sd);
     }
+
 #else
 void netCloseConnection(int sd)
     {
     close(sd);
     }
+
 #endif
 
 /*--------------------------------------------------------------------------
@@ -168,13 +174,13 @@ void netCloseConnection(int sd)
 #if defined(_WIN32)
 SOCKET netCreateListener(int port)
 #else
-int    netCreateListener(int port)
+int netCreateListener(int port)
 #endif
     {
 #if defined(_WIN32)
     SOCKET sd;
 #else
-    int    sd;
+    int sd;
 #endif
 
 #if DEBUG
@@ -190,8 +196,9 @@ int    netCreateListener(int port)
 #endif
         {
 #if DEBUG
-        fprintf(stderr, "(net_util) netCreateSocket could not create socket\n");
+        logDtError(LogErrorLocation, "(net_util) netCreateSocket could not create socket\n");
 #endif
+
         return sd;
         }
 
@@ -206,15 +213,17 @@ int    netCreateListener(int port)
 #endif
 #if defined(_WIN32)
         closesocket(sd);
+
         return INVALID_SOCKET;
 #else
         close(sd);
+
         return -1;
 #endif
         }
 
 #if DEBUG >= 2
-    fprintf(stderr, "(net_util) netCreateSocket listen on port %d succeeded\n", port);
+    logDtError(LogErrorLocation, "(net_util) netCreateSocket listen on port %d succeeded\n", port);
 #endif
 
     return sd;
@@ -234,18 +243,15 @@ int    netCreateListener(int port)
 #if defined(_WIN32)
 SOCKET netCreateSocket(int port, bool isReuse)
 #else
-int    netCreateSocket(int port, bool isReuse)
+int netCreateSocket(int port, bool isReuse)
 #endif
     {
-    int                optEnable = 1;
-    int                rc;
+    int optEnable = 1;
     struct sockaddr_in srcAddr;
 
 #if defined(_WIN32)
-    u_long    blockEnable = 1;
-    int       optLen;
-    int       optVal;
-    SOCKET    sd;
+    u_long blockEnable = 1;
+    SOCKET sd;
 #else
     socklen_t optLen;
     int       optVal;
@@ -258,9 +264,15 @@ int    netCreateSocket(int port, bool isReuse)
 
     sd = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
 #if defined(_WIN32)
-    if (sd == INVALID_SOCKET) return sd;
+    if (sd == INVALID_SOCKET)
+        {
+        return sd;
+        }
 #else
-    if (sd == -1) return sd;
+    if (sd == -1)
+        {
+        return sd;
+        }
 #endif
 
     if (isReuse)
@@ -280,9 +292,11 @@ int    netCreateSocket(int port, bool isReuse)
 #endif
 #if defined(_WIN32)
         closesocket(sd);
+
         return INVALID_SOCKET;
 #else
         close(sd);
+
         return -1;
 #endif
         }
@@ -296,8 +310,9 @@ int    netCreateSocket(int port, bool isReuse)
 #endif
 
 #if DEBUG >= 2
-    fprintf(stderr, "(net_util) netCreateSocket to %s:%d successful\n", ipAddress, port);
+    logDtError(LogErrorLocation, "(net_util) netCreateSocket to %s:%d successful\n", ipAddress, port);
 #endif
+
     return sd;
     }
 
@@ -367,11 +382,12 @@ char *netGetLocalTcpAddress(int sd)
         ipAddr = ntohl(hostAddr.sin_addr.s_addr);
         port   = ntohs(hostAddr.sin_port);
         sprintf(outBuf, "%d.%d.%d.%d:%d",
-          (ipAddr >> 24) & 0xff,
-          (ipAddr >> 16) & 0xff,
-          (ipAddr >>  8) & 0xff,
-          ipAddr         & 0xff,
-          port);
+                (ipAddr >> 24) & 0xff,
+                (ipAddr >> 16) & 0xff,
+                (ipAddr >> 8) & 0xff,
+                ipAddr & 0xff,
+                port);
+
         return outBuf;
         }
     else
@@ -414,11 +430,12 @@ char *netGetPeerTcpAddress(int sd)
         ipAddr = ntohl(hostAddr.sin_addr.s_addr);
         port   = ntohs(hostAddr.sin_port);
         sprintf(outBuf, "%d.%d.%d.%d:%d",
-          (ipAddr >> 24) & 0xff,
-          (ipAddr >> 16) & 0xff,
-          (ipAddr >>  8) & 0xff,
-          ipAddr         & 0xff,
-          port);
+                (ipAddr >> 24) & 0xff,
+                (ipAddr >> 16) & 0xff,
+                (ipAddr >> 8) & 0xff,
+                ipAddr & 0xff,
+                port);
+
         return outBuf;
         }
     else
@@ -458,7 +475,10 @@ int    netInitiateConnection(struct sockaddr *sap)
     sd = netCreateSocket(0, FALSE);
 
 #if defined(_WIN32)
-    if (sd == INVALID_SOCKET) return sd;
+    if (sd == INVALID_SOCKET)
+        {
+        return sd;
+        }
     rc = connect(sd, sap, sizeof(*sap));
     if ((rc == SOCKET_ERROR) && (WSAGetLastError() != WSAEWOULDBLOCK))
         {
@@ -466,10 +486,14 @@ int    netInitiateConnection(struct sockaddr *sap)
         perror("(net_util) connect");
 #endif
         closesocket(sd);
+
         return INVALID_SOCKET;
         }
 #else
-    if (sd == -1) return sd;
+    if (sd == -1)
+        {
+        return sd;
+        }
     rc = connect(sd, sap, sizeof(*sap));
     if ((rc == -1) && (errno != EINPROGRESS))
         {
@@ -477,12 +501,13 @@ int    netInitiateConnection(struct sockaddr *sap)
         perror("(net_util) connect");
 #endif
         close(sd);
+
         return -1;
         }
 #endif
 
 #if DEBUG >= 2
-    fprintf(stderr, "(net_util) connect succeeded\n");
+    logDtError(LogErrorLocation, "(net_util) connect succeeded\n");
 #endif
 
     return sd;

--- a/npu.h
+++ b/npu.h
@@ -315,7 +315,7 @@
 #define MaxBuffer                  2048
 #define MaxHaspStreams             7
 #define MaxTcbs                    256
-#define MaxTermDefs                64
+#define MaxTermDefs                255
 #define MinNjeBlockSize            1024
 
 /*

--- a/npu_async.c
+++ b/npu_async.c
@@ -325,7 +325,7 @@ void npuAsyncProcessTelnetData(Pcb *pcbp)
 
         case StTelnetProtoElem:
             switch (*sp++)
-            {
+                {
             case TELNET_IAC:
                 *dp++ = TELNET_IAC;
                 break;
@@ -403,7 +403,7 @@ void npuAsyncProcessTelnetData(Pcb *pcbp)
             default:
                 pcbp->controls.async.state = StTelnetData;
                 break;
-            }
+                }
             break;
 
         case StTelnetDont:

--- a/npu_bip.c
+++ b/npu_bip.c
@@ -40,7 +40,7 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
-#endif 
+#endif
 
 #include "const.h"
 #include "types.h"
@@ -107,19 +107,19 @@ bipState = BipIdle;
 ** Function tables to interface to either CCP or CCI functions
 */
 
-static bool (*hipDownlineBlock[])(NpuBuffer *np  ) =
+static bool (*hipDownlineBlock[])(NpuBuffer *np) =
     {
     npuHipDownlineBlock,
     cciHipDownlineBlock
     };
 
-static bool (*hipUplineBlock[])(NpuBuffer *np  ) =
+static bool (*hipUplineBlock[])(NpuBuffer *np) =
     {
     npuHipUplineBlock,
     cciHipUplineBlock
     };
 
-static void (*svmProcessBuffer[])(NpuBuffer *np ) =
+static void (*svmProcessBuffer[])(NpuBuffer *np) =
     {
     npuSvmProcessBuffer,
     cciSvmProcessBuffer
@@ -160,7 +160,7 @@ void npuBipInit(void)
     buffers  = bufPool = calloc(NumBuffs, sizeof(NpuBuffer));
     if (bufPool == NULL)
         {
-        fprintf(stderr, "Failed to allocate NPU data buffer pool\n");
+        logDtError(LogErrorLocation, "Failed to allocate NPU data buffer pool\n");
         exit(1);
         }
 
@@ -186,7 +186,7 @@ void npuBipInit(void)
     bipUplineQueue = calloc(1, sizeof(NpuQueue));
     if (bipUplineQueue == NULL)
         {
-        fprintf(stderr, "(npu_bip) Failed to allocate NPU buffer queue\n");
+        logDtError(LogErrorLocation, "(npu_bip) Failed to allocate NPU buffer queue\n");
         exit(1);
         }
     }
@@ -285,21 +285,21 @@ NpuBuffer *npuBipBufGet(void)
 
             for (i = 1, bp = buffers; i <= NumBuffs; i++, bp++)
                 {
-                fprintf(stderr, "\nBuffer %d, offset=%u, numBytes=%u, blockSeqNo=%u\n",
-                        i, bp->offset, bp->numBytes, bp->blockSeqNo);
+                logDtError(LogErrorLocation, "\nBuffer %d, offset=%u, numBytes=%u, blockSeqNo=%u\n",
+                           i, bp->offset, bp->numBytes, bp->blockSeqNo);
                 data = bp->data;
                 for (j = 0; j < 2; j++)
                     {
                     for (k = 0; k < 16; k++)
                         {
-                        fprintf(stderr, "%02X ", *data++);
+                        logDtError(LogErrorLocation, "%02X ", *data++);
                         }
                     data -= 16;
                     for (k = 0; k < 16; k++)
                         {
                         if ((*data >= 0x20) && (*data < 0x7f))
                             {
-                            fprintf(stderr, "%c", *data);
+                            logDtError(LogErrorLocation, "%c", *data);
                             }
                         else
                             {
@@ -330,7 +330,7 @@ NpuBuffer *npuBipBufGet(void)
 **------------------------------------------------------------------------*/
 bool npuBipIsBusy(void)
     {
-    return (NumBuffs - bufCount) >= idleNetBufs;
+    return (NumBuffs - bufCount) >= (int)idleNetBufs;
     }
 
 /*--------------------------------------------------------------------------
@@ -631,6 +631,7 @@ void npuBipRequestUplineTransfer(NpuBuffer *bp)
 
         return;
         }
+
     /*
     **  Send this block now.
     */

--- a/npu_hasp.c
+++ b/npu_hasp.c
@@ -369,7 +369,7 @@ void npuHaspTryOutput(Pcb *pcbp)
             scbp->recordCount  = 0;
             scbp->lastSRCB     = 0;
             switch (scbp->tp->deviceType)
-            {
+                {
             case DtCR:
                 ptiRecord[1] = 0x80 | (scbp->tp->streamId << 4) | 3;
                 break;
@@ -381,7 +381,7 @@ void npuHaspTryOutput(Pcb *pcbp)
             case DtCP:
                 ptiRecord[1] = 0x80 | (scbp->tp->streamId << 4) | 5;
                 break;
-            }
+                }
             npuHaspAppendRecord(pcbp, ptiRecord, sizeof(ptiRecord));
             npuHaspAppendOutput(pcbp, blockTrailer, sizeof(blockTrailer));
             if (npuHaspFlushBuffer(pcbp))
@@ -436,7 +436,7 @@ void npuHaspTryOutput(Pcb *pcbp)
         **  request to initiate transmission.
         */
         switch (scbp->state)
-        {
+            {
         case StHaspStreamReady:
         case StHaspStreamSendRTI:
         case StHaspStreamWaitAcctng:
@@ -453,7 +453,7 @@ void npuHaspTryOutput(Pcb *pcbp)
                     pcbp->claPort, scbp->state, scbp->tp->streamId, scbp->tp->termName);
 #endif
             break;
-        }
+            }
         break;
 
     case StHaspMajorSendENQ:
@@ -956,7 +956,7 @@ void npuHaspProcessUplineData(Pcb *pcbp)
         */
         case StHaspMinorRecvBOF:
             switch (ch)
-            {
+                {
             case SYN:
                 // Do nothing, continue searching for beginning of frame
                 break;
@@ -1013,7 +1013,7 @@ void npuHaspProcessUplineData(Pcb *pcbp)
                         pcbp->claPort, ch);
 #endif
                 break;
-            }
+                }
             break;
 
         /*
@@ -1023,7 +1023,7 @@ void npuHaspProcessUplineData(Pcb *pcbp)
         case StHaspMinorRecvSTX:
             pcbp->controls.hasp.lastRecvFrameType = ch;
             switch (ch)
-            {
+                {
             case STX:
                 pcbp->controls.hasp.minorState = StHaspMinorRecvBCB;
                 break;
@@ -1040,7 +1040,7 @@ void npuHaspProcessUplineData(Pcb *pcbp)
 #endif
                 pcbp->controls.hasp.minorState = StHaspMinorRecvBOF;
                 break;
-            }
+                }
             break;
 
         /*
@@ -1049,7 +1049,7 @@ void npuHaspProcessUplineData(Pcb *pcbp)
         */
         case StHaspMinorRecvENQ_Resp:
             switch (ch)
-            {
+                {
             case SYN:
                 // Do nothing, continue waiting for response
                 break;
@@ -1065,7 +1065,7 @@ void npuHaspProcessUplineData(Pcb *pcbp)
                         pcbp->claPort, ch);
 #endif
                 break;
-            }
+                }
             break;
 
         /*
@@ -1075,7 +1075,7 @@ void npuHaspProcessUplineData(Pcb *pcbp)
         case StHaspMinorRecvACK0:
             pcbp->controls.hasp.lastRecvFrameType = ch;
             switch (ch)
-            {
+                {
             case ACK0:
                 pcbp->controls.hasp.majorState = StHaspMajorWaitSignon;
                 break;
@@ -1086,7 +1086,7 @@ void npuHaspProcessUplineData(Pcb *pcbp)
                         pcbp->claPort, ch);
 #endif
                 break;
-            }
+                }
             break;
 
         /*
@@ -1107,7 +1107,7 @@ void npuHaspProcessUplineData(Pcb *pcbp)
         */
         case StHaspMinorRecvENQ:
             switch (ch)
-            {
+                {
             case ENQ:
                 if (pcbp->controls.hasp.consoleStream.tp != NULL)
                     {
@@ -1139,7 +1139,7 @@ void npuHaspProcessUplineData(Pcb *pcbp)
             default:
                 pcbp->controls.hasp.minorState = StHaspMinorRecvSOH;
                 break;
-            }
+                }
             break;
 
         /*
@@ -1150,7 +1150,7 @@ void npuHaspProcessUplineData(Pcb *pcbp)
                 {
                 blockSeqNum = ch & 0x0f;
                 switch ((ch >> 4) & 0x07)
-                {
+                    {
                 case 0x00: // Normal Block
                     if (blockSeqNum == ((pcbp->controls.hasp.uplineBSN + 1) & 0x0f))
                         {
@@ -1184,7 +1184,7 @@ void npuHaspProcessUplineData(Pcb *pcbp)
 #endif
                     pcbp->controls.hasp.minorState = StHaspMinorRecvDLE2;
                     break;
-                }
+                    }
                 }
             else
                 {
@@ -1286,10 +1286,10 @@ void npuHaspProcessUplineData(Pcb *pcbp)
                 recordType = ch & 0x0f;
                 streamId   = (ch >> 4) & 0x07;
                 switch (recordType)
-                {
+                    {
                 case 0x00:            // Control record
                     switch (streamId) // stream id is control info for control record
-                    {
+                        {
                     case 1:           // Request to initiate a function transmission
                         pcbp->controls.hasp.sRCBType = SRCB_RTI;
                         break;
@@ -1313,7 +1313,7 @@ void npuHaspProcessUplineData(Pcb *pcbp)
 #endif
                         pcbp->controls.hasp.minorState = StHaspMinorRecvDLE2;
                         break;
-                    }
+                        }
                     continue;
 
                 case 0x01: // Operator message display request
@@ -1349,7 +1349,7 @@ void npuHaspProcessUplineData(Pcb *pcbp)
                     deviceType = 0xff;
                     pcbp->controls.hasp.minorState = StHaspMinorRecvDLE2;
                     continue;
-                }
+                    }
                 scbp = npuHaspFindStream(pcbp, streamId, deviceType);
                 if (scbp != NULL)
                     {
@@ -1366,12 +1366,12 @@ void npuHaspProcessUplineData(Pcb *pcbp)
                 {
                 pcbp->controls.hasp.minorState = StHaspMinorRecvSCB0;
                 switch (pcbp->controls.hasp.sRCBType)
-                {
+                    {
                 case SRCB_RTI: // Request To Initiate transmission
                     streamId   = (ch >> 4) & 0x07;
                     deviceType = ch & 0x0f;
                     switch (deviceType)
-                    {
+                        {
                     case 3: // Reader
                         scbp = npuHaspFindStream(pcbp, streamId, DtCR);
                         break;
@@ -1391,7 +1391,7 @@ void npuHaspProcessUplineData(Pcb *pcbp)
 #endif
                         scbp = NULL;
                         break;
-                    }
+                        }
                     if (scbp != NULL)
                         {
                         if ((scbp->tp == NULL)
@@ -1414,7 +1414,7 @@ void npuHaspProcessUplineData(Pcb *pcbp)
                     streamId   = (ch >> 4) & 0x07;
                     deviceType = ch & 0x0f;
                     switch (deviceType)
-                    {
+                        {
                     case 3: // Reader
                         scbp = npuHaspFindStream(pcbp, streamId, DtCR);
                         break;
@@ -1434,7 +1434,7 @@ void npuHaspProcessUplineData(Pcb *pcbp)
 #endif
                         scbp = NULL;
                         break;
-                    }
+                        }
                     if (scbp != NULL)
                         {
                         scbp->state       = StHaspStreamReady;
@@ -1445,7 +1445,7 @@ void npuHaspProcessUplineData(Pcb *pcbp)
 
                 case SRCB_GCR: // General Control Record
                     switch (ebcdicToAscii[ch])
-                    {
+                        {
                     case 'A': // Signon record
                         pcbp->controls.hasp.minorState = StHaspMinorRecvSignon;
                         break;
@@ -1464,7 +1464,7 @@ void npuHaspProcessUplineData(Pcb *pcbp)
                                 pcbp->claPort, (char)ebcdicToAscii[ch]);
 #endif
                         break;
-                    }
+                        }
                     break;
 
                 case SRCB_LP: // Print record
@@ -1482,7 +1482,7 @@ void npuHaspProcessUplineData(Pcb *pcbp)
 
                 default: // do nothing for other SRCB types
                     break;
-                }
+                    }
                 }
             else
                 {
@@ -1804,7 +1804,7 @@ void npuHaspProcessUplineData(Pcb *pcbp)
         */
         case StHaspMinorRecvDLE2:
             switch (ch)
-            {
+                {
             case DLE:
                 pcbp->controls.hasp.minorState = StHaspMinorRecvETB2;
                 break;
@@ -1820,7 +1820,7 @@ void npuHaspProcessUplineData(Pcb *pcbp)
 
             default:
                 break;
-            }
+                }
             break;
 
         /*
@@ -2850,7 +2850,7 @@ static int npuHaspFlushPruPostPrintFragment(Tcb *tp)
     default:
         fe = ebcdicToAscii[*scbp->pruFragment2];
         switch (fe)
-        {
+            {
         case '0': // space two lines after print
             srcb = 0x02;
             break;
@@ -2890,7 +2890,7 @@ static int npuHaspFlushPruPostPrintFragment(Tcb *tp)
         default:
             srcb = 0x01;
             break;
-        }
+            }
         break;
         }
     len = npuHaspSendRecordHeader(tp, srcb);

--- a/npu_hasp.c
+++ b/npu_hasp.c
@@ -53,7 +53,7 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
-#endif 
+#endif
 
 #include <stdarg.h>
 #include <string.h>
@@ -74,67 +74,67 @@
 **  -----------------
 */
 
-#define BlockCushion        140
-#define DeadPeerTimeout     15000
-#define HaspPduHdrLen       5
-#define HaspMaxPruDataSize  1280
-#define HaspStartTimeout    (5 * 60 * 1000)
-#define InBufThreshold      (HaspMaxPruDataSize + HaspPduHdrLen)
-#define MaxRetries          5
-#define PauseTimeout        100
-#define RecvTimeout         5000
-#define SendTimeout         100
+#define BlockCushion          140
+#define DeadPeerTimeout       15000
+#define HaspPduHdrLen         5
+#define HaspMaxPruDataSize    1280
+#define HaspStartTimeout      (5 * 60 * 1000)
+#define InBufThreshold        (HaspMaxPruDataSize + HaspPduHdrLen)
+#define MaxRetries            5
+#define PauseTimeout          100
+#define RecvTimeout           5000
+#define SendTimeout           100
 
-#define SOH                 0x01
-#define STX                 0x02
-#define ETX                 0x03
-#define DLE                 0x10
-#define ITB                 0x1f
-#define ETB                 0x26
-#define ENQ                 0x2d
-#define SYN                 0x32
-#define EOT                 0x37
-#define NAK                 0x3d
-#define ACK0                0x70
+#define SOH                   0x01
+#define STX                   0x02
+#define ETX                   0x03
+#define DLE                   0x10
+#define ITB                   0x1f
+#define ETB                   0x26
+#define ENQ                   0x2d
+#define SYN                   0x32
+#define EOT                   0x37
+#define NAK                   0x3d
+#define ACK0                  0x70
 
-#define DcBlank             055
-#define EbcdicBlank         0x40
+#define DcBlank               055
+#define EbcdicBlank           0x40
 
-#define SRCB_GCR            0
-#define SRCB_RTI            1
-#define SRCB_PTI            2
-#define SRCB_CI             3
-#define SRCB_CO             4
-#define SRCB_LP             5
-#define SRCB_CP             6
-#define SRCB_CR             7
-#define SRCB_BAD_BCB        8
+#define SRCB_GCR              0
+#define SRCB_RTI              1
+#define SRCB_PTI              2
+#define SRCB_CI               3
+#define SRCB_CO               4
+#define SRCB_LP               5
+#define SRCB_CP               6
+#define SRCB_CR               7
+#define SRCB_BAD_BCB          8
 
 /*
 **  Field name codes used in setting batch device parameters.
 */
-#define FnDevTbsUpper       30 // TBS upper 3 bits
-#define FnDevTbsLower       31 // TBS lower 8 bits
-#define FnDevPW             35 // Page width
-#define FnDevPL             36 // Page length
-#define FnDevPrintTrain     76 // Print train type
+#define FnDevTbsUpper         30 // TBS upper 3 bits
+#define FnDevTbsLower         31 // TBS lower 8 bits
+#define FnDevPW               35 // Page width
+#define FnDevPL               36 // Page length
+#define FnDevPrintTrain       76 // Print train type
 
 /*
 **  Field name codes used in setting batch file parameters.
 */
-#define FnFileType          81 // File type
-#define FnFileCC            82 // Carriage control
-#define FnFileLace          83 // Lace card punching
-#define FnFileLimUpper      84 // File limit upper byte
-#define FnFileLimLower      85 // File limit lower byte
-#define FnFilePunchLimit    86 // Punch limit
+#define FnFileType            81 // File type
+#define FnFileCC              82 // Carriage control
+#define FnFileLace            83 // Lace card punching
+#define FnFileLimUpper        84 // File limit upper byte
+#define FnFileLimLower        85 // File limit lower byte
+#define FnFilePunchLimit      86 // Punch limit
 
 /*
 **  -----------------------
 **  Private Macro Functions
 **  -----------------------
 */
-#define isPostPrint(tp) ((tp)->params.fvTC == TcHASP)
+#define isPostPrint(tp)    ((tp)->params.fvTC == TcHASP)
 #if DEBUG
 #define HexColumn(x)    (3 * (x) + 4)
 #define AsciiColumn(x)  (HexColumn(16) + 2 + (x))
@@ -273,7 +273,7 @@ void npuHaspTryOutput(Pcb *pcbp)
 
     /*
      *  Process HASP protocol output
-     */ 
+     */
     currentTime = getMilliseconds();
 
     switch (pcbp->controls.hasp.majorState)
@@ -369,7 +369,7 @@ void npuHaspTryOutput(Pcb *pcbp)
             scbp->recordCount  = 0;
             scbp->lastSRCB     = 0;
             switch (scbp->tp->deviceType)
-                {
+            {
             case DtCR:
                 ptiRecord[1] = 0x80 | (scbp->tp->streamId << 4) | 3;
                 break;
@@ -399,7 +399,7 @@ void npuHaspTryOutput(Pcb *pcbp)
         if (scbp == NULL)
             {
             scbp = npuHaspFindStreamWithOutput(pcbp);
-            if (scbp == NULL || scbp->isTerminateRequested)
+            if ((scbp == NULL) || scbp->isTerminateRequested)
                 {
                 /*
                 **  No streams have output to send, so send ACK0 frame.  However, if the
@@ -415,7 +415,7 @@ void npuHaspTryOutput(Pcb *pcbp)
                         {
                         pcbp->controls.hasp.sendDeadline = currentTime + SendTimeout;
                         }
-                    if (scbp != NULL && scbp->isTerminateRequested)
+                    if ((scbp != NULL) && scbp->isTerminateRequested)
                         {
                         npuHaspSendUplineEoiAcctg(scbp->tp, SfcIOT);
                         scbp->isTerminateRequested = FALSE;
@@ -436,7 +436,7 @@ void npuHaspTryOutput(Pcb *pcbp)
         **  request to initiate transmission.
         */
         switch (scbp->state)
-            {
+        {
         case StHaspStreamReady:
         case StHaspStreamSendRTI:
         case StHaspStreamWaitAcctng:
@@ -505,8 +505,8 @@ void npuHaspTryOutput(Pcb *pcbp)
         break;
 
     default:
-        fprintf(stderr, "(npu_hasp) Port %02x: invalid  major state: %02x\n",
-                pcbp->claPort, pcbp->controls.hasp.majorState);
+        logDtError(LogErrorLocation, "(npu_hasp) Port %02x: invalid  major state: %02x\n",
+                   pcbp->claPort, pcbp->controls.hasp.majorState);
         pcbp->controls.hasp.majorState = StHaspMajorInit;
         break;
         }
@@ -552,7 +552,7 @@ void npuHaspProcessDownlineData(Tcb *tp, NpuBuffer *bp, bool last)
     if ((dbc & DbcPRU) != 0)
         {
         npuHaspLogBytes(bp->data, bp->numBytes,
-            (tp->scbp != NULL && tp->scbp->params.fvFileType == ASC) ? ASCII : DisplayCode);
+                        (tp->scbp != NULL && tp->scbp->params.fvFileType == ASC) ? ASCII : DisplayCode);
         }
     else if ((dbc & DbcTransparent) == 0)
         {
@@ -605,8 +605,8 @@ void npuHaspProcessDownlineData(Tcb *tp, NpuBuffer *bp, bool last)
             }
         blockLen = npuHaspSendBlockHeader(tp);
         npuNetSend(tp, rtiRecord, sizeof(rtiRecord));
-        blockLen += sizeof(rtiRecord);
-        blockLen += npuHaspSendBlockTrailer(tp);
+        blockLen   += sizeof(rtiRecord);
+        blockLen   += npuHaspSendBlockTrailer(tp);
         scbp->state = StHaspStreamSendRTI;
         npuBipQueueAppend(npuBipBufGet(), &tp->outputQ);
         npuHaspResetSendDeadline(tp);
@@ -649,7 +649,7 @@ void npuHaspProcessDownlineData(Tcb *tp, NpuBuffer *bp, bool last)
 
             return;
             }
-        blockLen = 0;
+        blockLen     = 0;
         blocksQueued = 0;
         while (len > 0)
             {
@@ -659,7 +659,10 @@ void npuHaspProcessDownlineData(Tcb *tp, NpuBuffer *bp, bool last)
                 **  A complete record has been collected, so flush the record
                 **  to the output stream.
                 */
-                if (blockLen == 0) blockLen = npuHaspSendBlockHeader(tp);
+                if (blockLen == 0)
+                    {
+                    blockLen = npuHaspSendBlockHeader(tp);
+                    }
                 blockLen += npuHaspFlushPruFragment(tp);
                 if (blockLen > pcbp->controls.hasp.blockSize - BlockCushion)
                     {
@@ -671,7 +674,7 @@ void npuHaspProcessDownlineData(Tcb *tp, NpuBuffer *bp, bool last)
                     blockLen += npuHaspSendBlockTrailer(tp);
                     npuBipQueueAppend(npuBipBufGet(), &tp->outputQ);
                     blocksQueued += 1;
-                    blockLen = 0;
+                    blockLen      = 0;
                     }
                 }
             if (scbp->params.fvFileType == ASC)
@@ -713,14 +716,17 @@ void npuHaspProcessDownlineData(Tcb *tp, NpuBuffer *bp, bool last)
             }
         if (scbp->isPruFragmentComplete)
             {
-            if (blockLen == 0) blockLen = npuHaspSendBlockHeader(tp);
+            if (blockLen == 0)
+                {
+                blockLen = npuHaspSendBlockHeader(tp);
+                }
             blockLen += npuHaspFlushPruFragment(tp);
             if (blockLen > pcbp->controls.hasp.blockSize - BlockCushion)
                 {
                 blockLen += npuHaspSendBlockTrailer(tp);
                 npuBipQueueAppend(npuBipBufGet(), &tp->outputQ);
                 blocksQueued += 1;
-                blockLen = 0;
+                blockLen      = 0;
                 }
             }
         if ((dbc & DbcAcctg) == DbcAcctg) // EOI accounting record
@@ -732,15 +738,21 @@ void npuHaspProcessDownlineData(Tcb *tp, NpuBuffer *bp, bool last)
             */
             if (scbp->pruFragmentSize > 0)
                 {
-                if (blockLen == 0) blockLen = npuHaspSendBlockHeader(tp);
+                if (blockLen == 0)
+                    {
+                    blockLen = npuHaspSendBlockHeader(tp);
+                    }
                 blockLen += npuHaspFlushPruFragment(tp);
                 }
-            if (blockLen == 0) blockLen = npuHaspSendBlockHeader(tp);
+            if (blockLen == 0)
+                {
+                blockLen = npuHaspSendBlockHeader(tp);
+                }
             blockLen += npuHaspSendEofRecord(tp);
             }
         if (blockLen > 0)
             {
-            blockLen += npuHaspSendBlockTrailer(tp);
+            blockLen     += npuHaspSendBlockTrailer(tp);
             blocksQueued += 1;
             }
         if (blocksQueued > 0)
@@ -799,7 +811,7 @@ void npuHaspProcessDownlineData(Tcb *tp, NpuBuffer *bp, bool last)
                     }
                 }
             blockLen += npuHaspSendRecordHeader(tp, srcb);
-            recordLen = blk - recordStart;
+            recordLen = (u8)(blk - recordStart);
             if (recordLen > 0)
                 {
                 blockLen += npuHaspSendRecordStrings(tp, recordStart, recordLen);
@@ -870,8 +882,8 @@ void npuHaspProcessDownlineData(Tcb *tp, NpuBuffer *bp, bool last)
                 {
                 blockLen += npuHaspSendRecordStrings(tp, blank, sizeof(blank));
                 }
-            blk      += recordLen;
-            len      -= recordLen;
+            blk += recordLen;
+            len -= recordLen;
             if ((blockLen > pcbp->controls.hasp.blockSize - BlockCushion) && (len > 0))
                 {
                 blockLen += npuHaspSendBlockTrailer(tp);
@@ -1581,7 +1593,7 @@ void npuHaspProcessUplineData(Pcb *pcbp)
             scbp = pcbp->controls.hasp.designatedStream;
             if (ch == 0x00) // if RCB is 0x00 then EOF detected
                 {
-                if (scbp->tp->deviceType == DtLP && scbp->lastSRCB != 0)
+                if ((scbp->tp->deviceType == DtLP) && (scbp->lastSRCB != 0))
                     {
                     buf[0] = npuHaspTranslateSrcbToFe(scbp->lastSRCB);
                     buf[1] = EbcdicBlank;
@@ -1855,8 +1867,8 @@ void npuHaspProcessUplineData(Pcb *pcbp)
 
         // else fall through
         default:
-            fprintf(stderr, "(npu_hasp) Port %02x: invalid minor state: %02x\n",
-                    pcbp->claPort, pcbp->controls.hasp.minorState);
+            logDtError(LogErrorLocation, "(npu_hasp) Port %02x: invalid minor state: %02x\n",
+                       pcbp->claPort, pcbp->controls.hasp.minorState);
             pcbp->controls.hasp.minorState = StHaspMinorRecvBOF;
 
             return;
@@ -1965,7 +1977,6 @@ bool npuHaspNotifyNetConnect(Pcb *pcbp, bool isPassive)
 **------------------------------------------------------------------------*/
 void npuHaspNotifyNetDisconnect(Pcb *pcbp)
     {
-    int i;
     Tcb *tp;
 
 #if DEBUG
@@ -2347,16 +2358,16 @@ void npuHaspPresetPcb(Pcb *pcbp)
         npuHaspLog = fopen("hasplog.txt", "wt");
         if (npuHaspLog == NULL)
             {
-            fprintf(stderr, "hasplog.txt - aborting\n");
+            logDtError(LogErrorLocation, "hasplog.txt - aborting\n");
             exit(1);
             }
         npuHaspLogFlush();    // initialize log buffer
         }
 #endif
 
-    pcbp->controls.hasp.lastBlockSent         = NULL;
-    pcbp->controls.hasp.retries               = 0;
-    pcbp->controls.hasp.outBuf                = NULL;
+    pcbp->controls.hasp.lastBlockSent = NULL;
+    pcbp->controls.hasp.retries       = 0;
+    pcbp->controls.hasp.outBuf        = NULL;
     memset(&pcbp->controls.hasp.consoleStream.uplineQ, 0, sizeof(NpuQueue));
 
     for (i = 0; i < MaxHaspStreams; ++i)
@@ -2370,7 +2381,7 @@ void npuHaspPresetPcb(Pcb *pcbp)
             scbp->pruFragment = (u8 *)malloc(MaxBuffer);
             if (scbp->pruFragment == NULL)
                 {
-                fprintf(stderr, "Failed to allocate PRU fragment buffer for HASP print stream\n");
+                logDtError(LogErrorLocation, "Failed to allocate PRU fragment buffer for HASP print stream\n");
                 exit(1);
                 }
             }
@@ -2387,7 +2398,7 @@ void npuHaspPresetPcb(Pcb *pcbp)
             scbp->pruFragment = (u8 *)malloc(MaxBuffer);
             if (scbp->pruFragment == NULL)
                 {
-                fprintf(stderr, "Failed to allocate PRU fragment buffer for HASP punch stream\n");
+                logDtError(LogErrorLocation, "Failed to allocate PRU fragment buffer for HASP punch stream\n");
                 exit(1);
                 }
             }
@@ -2592,7 +2603,7 @@ static Scb *npuHaspFindStreamWithOutput(Pcb *pcbp)
         toReqScbp = NULL;
         for (i = 0; i < MaxHaspStreams * 2; i++)
             {
-            pi = (pollIndex + i) % (MaxHaspStreams * 2);
+            pi   = (pollIndex + i) % (MaxHaspStreams * 2);
             scbp = (pi < MaxHaspStreams)
                 ? &pcbp->controls.hasp.printStreams[pi]
                 : &pcbp->controls.hasp.punchStreams[pi - MaxHaspStreams];
@@ -2602,17 +2613,20 @@ static Scb *npuHaspFindStreamWithOutput(Pcb *pcbp)
                     {
                     return toReqScbp = scbp;
                     }
-                if ((scbp->state == StHaspStreamReady
-                          || scbp->state == StHaspStreamSendRTI
-                          || scbp->state == StHaspStreamWaitAcctng)
-                         && scbp->tp->xoff == FALSE
-                         && npuBipQueueNotEmpty(&scbp->tp->outputQ))
+                if (((scbp->state == StHaspStreamReady)
+                     || (scbp->state == StHaspStreamSendRTI)
+                     || (scbp->state == StHaspStreamWaitAcctng))
+                    && (scbp->tp->xoff == FALSE)
+                    && npuBipQueueNotEmpty(&scbp->tp->outputQ))
                     {
                     return scbp;
                     }
                 }
             }
-            if (toReqScbp != NULL) return toReqScbp;
+        if (toReqScbp != NULL)
+            {
+            return toReqScbp;
+            }
         }
     else // pcbp->ncbp->connType == ConnTypeRevHasp
         {
@@ -2703,6 +2717,7 @@ static int npuHaspFlushPruFragment(Tcb *tp)
             {
             scbp->pruFragment[scbp->pruFragmentSize++] = EbcdicBlank;
             }
+
         return isPostPrint(tp) ? npuHaspFlushPruPostPrintFragment(tp) : npuHaspFlushPruPrePrintFragment(tp);
         }
     else
@@ -2711,22 +2726,24 @@ static int npuHaspFlushPruFragment(Tcb *tp)
         fp   = scbp->pruFragment;
         size = scbp->pruFragmentSize;
 
-        if (tp->deviceType == DtCP && scbp->params.fvFileType == 1) // avoid sending lace card
+        if ((tp->deviceType == DtCP) && (scbp->params.fvFileType == 1)) // avoid sending lace card
             {
             scbp->pruFragmentSize       = 0;
             scbp->isPruFragmentComplete = FALSE;
+
             return 0;
             }
         else if (size < 1)
             {
-            fp = blank;
+            fp   = blank;
             size = sizeof(blank);
             }
         len  = npuHaspSendRecordHeader(tp, 0);
         len += npuHaspSendRecordStrings(tp, fp, size);
-        scbp->recordCount += 1;
+        scbp->recordCount          += 1;
         scbp->pruFragmentSize       = 0;
         scbp->isPruFragmentComplete = FALSE;
+
         return len;
         }
     }
@@ -2756,6 +2773,7 @@ static int npuHaspFlushPruPostPrintFragment(Tcb *tp)
     if (scbp->pruFragmentSize < 1)
         {
         scbp->isPruFragmentComplete = FALSE;
+
         return 0;
         }
     if (scbp->pruFragment2 == NULL)
@@ -2768,12 +2786,16 @@ static int npuHaspFlushPruPostPrintFragment(Tcb *tp)
         //
         dp = scbp->pruFragment + scbp->pruFragmentSize + 1;
         fp = dp - 2;
-        while (fp >= scbp->pruFragment) *dp-- = *fp--;
-        fp = scbp->pruFragment;
+        while (fp >= scbp->pruFragment)
+            {
+            *dp-- = *fp--;
+            }
+        fp    = scbp->pruFragment;
         *fp++ = EbcdicBlank;
         *fp++ = EbcdicBlank;
-        scbp->pruFragment2 = fp;
+        scbp->pruFragment2     = fp;
         scbp->pruFragmentSize += 2;
+
         return npuHaspFlushPruPostPrintFragment(tp);
         }
     //
@@ -2800,15 +2822,16 @@ static int npuHaspFlushPruPostPrintFragment(Tcb *tp)
         *scbp->pruFragment2 = EbcdicBlank;
         }
     fe = ebcdicToAscii[*scbp->pruFragment2];
-    if (fe >= 'Q' && fe <= 'T') // discard lines with these
+    if ((fe >= 'Q') && (fe <= 'T')) // discard lines with these
         {
-        scbp->pruFragmentSize = scbp->pruFragment2 - scbp->pruFragment;
+        scbp->pruFragmentSize       = (int)(scbp->pruFragment2 - scbp->pruFragment);
         scbp->isPruFragmentComplete = FALSE;
+
         return 0;
         }
-    fp = scbp->pruFragment;
-    fe = ebcdicToAscii[*fp++];
-    size = scbp->pruFragment2 - fp;
+    fp   = scbp->pruFragment;
+    fe   = ebcdicToAscii[*fp++];
+    size = (int)(scbp->pruFragment2 - fp);
     switch (fe)
         {
     case 'C': // skip to channel 6 after print
@@ -2827,7 +2850,7 @@ static int npuHaspFlushPruPostPrintFragment(Tcb *tp)
     default:
         fe = ebcdicToAscii[*scbp->pruFragment2];
         switch (fe)
-            {
+        {
         case '0': // space two lines after print
             srcb = 0x02;
             break;
@@ -2846,8 +2869,8 @@ static int npuHaspFlushPruPostPrintFragment(Tcb *tp)
         case '6': // skip to channel 3 after print
         case '7': // skip to channel 2 after print
         case '8': // skip to channel 1 after print
-          srcb = 0x11 + ('8' - fe);
-          break;
+            srcb = 0x11 + ('8' - fe);
+            break;
 
         case '-': // space three lines after print
             srcb = 0x03;
@@ -2867,18 +2890,18 @@ static int npuHaspFlushPruPostPrintFragment(Tcb *tp)
         default:
             srcb = 0x01;
             break;
-            }
+        }
         break;
         }
     len = npuHaspSendRecordHeader(tp, srcb);
     if (size < 1)
         {
-        fp = blank;
+        fp   = blank;
         size = sizeof(blank);
         }
     len += npuHaspSendRecordStrings(tp, fp, size);
-    scbp->recordCount += 1;
-    scbp->pruFragmentSize -= scbp->pruFragment2 - scbp->pruFragment;
+    scbp->recordCount     += 1;
+    scbp->pruFragmentSize -= (int)(scbp->pruFragment2 - scbp->pruFragment);
     if (scbp->pruFragmentSize > 0)
         {
         memcpy(scbp->pruFragment, scbp->pruFragment2, scbp->pruFragmentSize);
@@ -2889,6 +2912,7 @@ static int npuHaspFlushPruPostPrintFragment(Tcb *tp)
         scbp->pruFragment2 = NULL;
         }
     scbp->isPruFragmentComplete = FALSE;
+
     return len;
     }
 
@@ -2919,9 +2943,10 @@ static int npuHaspFlushPruPrePrintFragment(Tcb *tp)
     if (size < 1)
         {
         scbp->isPruFragmentComplete = FALSE;
+
         return 0;
         }
-    fe = ebcdicToAscii[*fp++];
+    fe    = ebcdicToAscii[*fp++];
     size -= 1;
     switch (fe)
         {
@@ -2943,8 +2968,8 @@ static int npuHaspFlushPruPrePrintFragment(Tcb *tp)
     case '6': // skip to channel 3 before print
     case '7': // skip to channel 2 before print
     case '8': // skip to channel 1 before print
-      srcb = 0x31 + ('8' - fe);
-      break;
+        srcb = 0x31 + ('8' - fe);
+        break;
 
     case 'C': // skip to channel 6 after print
     case 'D': // skip to channel 5 after print
@@ -2952,8 +2977,8 @@ static int npuHaspFlushPruPrePrintFragment(Tcb *tp)
     case 'F': // skip to channel 3 after print
     case 'G': // skip to channel 2 after print
     case 'H': // skip to channel 1 after print
-      srcb = 0x11 + ('H' - fe);
-      break;
+        srcb = 0x11 + ('H' - fe);
+        break;
 
     case 'Q': // suppress auto-eject
     case 'R': // set auto-eject
@@ -2961,6 +2986,7 @@ static int npuHaspFlushPruPrePrintFragment(Tcb *tp)
     case 'T': // set 8 LPI
         scbp->pruFragmentSize       = 0;
         scbp->isPruFragmentComplete = FALSE;
+
         return 0;
 
     case '-': // space two lines before print
@@ -2978,14 +3004,15 @@ static int npuHaspFlushPruPrePrintFragment(Tcb *tp)
         }
     if (size < 1)
         {
-        fp = blank;
+        fp   = blank;
         size = sizeof(blank);
         }
     len  = npuHaspSendRecordHeader(tp, srcb);
     len += npuHaspSendRecordStrings(tp, fp, size);
-    scbp->recordCount += 1;
+    scbp->recordCount          += 1;
     scbp->pruFragmentSize       = 0;
     scbp->isPruFragmentComplete = FALSE;
+
     return len;
     }
 
@@ -3017,26 +3044,26 @@ static void npuHaspFlushUplineData(Scb *scbp, bool isEof)
         {
         if (tp->deviceType == DtCONSOLE) // console input is IVT format
             {
-            recordLength = tp->inBufPtr - tp->inBufStart;
+            recordLength = (int)(tp->inBufPtr - tp->inBufStart);
             while (recordLength > 0 && *(tp->inBufPtr - 1) == ' ') // remove trailing blanks
                 {
                 tp->inBufPtr -= 1;
                 recordLength -= 1;
                 }
             *tp->inBufPtr++ = ChrUS;
-            numBytes        = tp->inBufPtr - tp->inBuf;
+            numBytes        = (int)(tp->inBufPtr - tp->inBuf);
             }
         else if (scbp->isDiscardingRecords)
             {
             tp->inBufPtr = tp->inBufStart;
-            numBytes     = tp->inBufPtr - tp->inBuf;
+            numBytes     = (int)(tp->inBufPtr - tp->inBuf);
             }
         else // card reader input is PRU format
             {
             //
             //  Trim trailing blanks
             //
-            recordLength = tp->inBufPtr - tp->inBufStart;
+            recordLength = (int)(tp->inBufPtr - tp->inBufStart);
             while (recordLength > 0 && *(tp->inBufPtr - 1) == DcBlank)
                 {
                 tp->inBufPtr -= 1;
@@ -3085,12 +3112,12 @@ static void npuHaspFlushUplineData(Scb *scbp, bool isEof)
                 scbp->recordCount += 1;
                 }
             }
-        numBytes = tp->inBufPtr - tp->inBuf;
+        numBytes = (int)(tp->inBufPtr - tp->inBuf);
         }
     else // ncbp->connType == ConnTypeRevHasp
         {
         scbp->recordCount += 1;
-        recordLength       = tp->inBufPtr - tp->inBufStart; // transparent record length
+        recordLength       = (int)(tp->inBufPtr - tp->inBufStart); // transparent record length
         if ((recordLength > 1) || (isEof == FALSE))
             {
             if (recordLength < 2) // ensure record has at least one character
@@ -3099,14 +3126,15 @@ static void npuHaspFlushUplineData(Scb *scbp, bool isEof)
                 recordLength   += 1;
                 }
             *tp->inBufStart = recordLength;
-            numBytes        = tp->inBufPtr - tp->inBuf;
+            numBytes        = (int)(tp->inBufPtr - tp->inBuf);
             tp->inBufStart  = tp->inBufPtr++;
             }
         else
             {
-            numBytes = tp->inBufStart - tp->inBuf;
+            numBytes = (int)(tp->inBufStart - tp->inBuf);
             }
         }
+
     /*
     **  If end of record, end of information, or buffer threshold reached,
     **  send staged records upline.
@@ -3124,16 +3152,19 @@ static void npuHaspFlushUplineData(Scb *scbp, bool isEof)
                 {
                 if (numBytes > InBufThreshold)
                     {
-                    tp->inBuf[BlkOffDbc] = DbcPRU;
+                    tp->inBuf[BlkOffDbc]   = DbcPRU;
                     tp->inBuf[BlkOffBTBSN] = (tp->uplineBsn << BlkShiftBSN) | BtHTMSG;
                     npuHaspSendUplineData(tp, tp->inBuf, InBufThreshold);
                     npuTipInputReset(tp);
                     numBytes -= InBufThreshold;
                     memcpy(tp->inBuf + HaspPduHdrLen, tp->inBuf + InBufThreshold, numBytes);
-                    numBytes += HaspPduHdrLen;
-                    tp->inBufPtr = tp->inBuf + numBytes;
+                    numBytes      += HaspPduHdrLen;
+                    tp->inBufPtr   = tp->inBuf + numBytes;
                     tp->inBufStart = tp->inBufPtr;
-                    if (isEof == FALSE && isEor == FALSE) return;
+                    if ((isEof == FALSE) && (isEor == FALSE))
+                        {
+                        return;
+                        }
                     }
                 if (isEof)
                     {
@@ -3225,10 +3256,10 @@ static void npuHaspProcessFormatControl(Pcb *pcbp)
 
     scbp  = pcbp->controls.hasp.designatedStream;
     param = pcbp->controls.hasp.sRCBParam & 0x3f;
-    cc = param;
+    cc    = param;
     if ((param & 0x20) == 0) // post-print, use last SRCB
         {
-        cc = scbp->lastSRCB;
+        cc             = scbp->lastSRCB;
         scbp->lastSRCB = param;
         }
     else if (scbp->lastSRCB != 0)
@@ -3370,6 +3401,7 @@ static int npuHaspSendBlockHeader(Tcb *tp)
     header[i++] = 0x80 | (0 << 6) | 0x0f; // normal state, all print/punch streams on
     header[i++] = 0x80 | (1 << 6) | 0x0f; // console on, all print/punch streams on
     npuNetSend(tp, header, i);
+
     return sizeof(blockHeader) + i;
     }
 
@@ -3399,6 +3431,7 @@ static int npuHaspSendBlockTrailer(Tcb *tp)
     header[i++] = DLE;
     header[i++] = ETB;
     npuNetSend(tp, header, i);
+
     return i;
     }
 
@@ -3527,12 +3560,13 @@ static bool npuHaspSendDownlineData(Tcb *tp)
 **------------------------------------------------------------------------*/
 static int npuHaspSendEofRecord(Tcb *tp)
     {
-    u8 data[1];
+    u8  data[1];
     int len;
 
-    len = npuHaspSendRecordHeader(tp, 0);
+    len     = npuHaspSendRecordHeader(tp, 0);
     data[0] = 0;
     npuNetSend(tp, data, 1);
+
     return len + 1;
     }
 
@@ -3596,6 +3630,7 @@ static int npuHaspSendRecordHeader(Tcb *tp, u8 srcb)
         return 0;
         }
     npuNetSend(tp, header, i);
+
     return i;
     }
 
@@ -3630,7 +3665,7 @@ static int npuHaspSendRecordStrings(Tcb *tp, u8 *data, int len)
         npuNetSend(tp, data, 63);
         data += 63;
         len  -= 63;
-        n += 64;
+        n    += 64;
         }
     if (len > 0)
         {
@@ -3641,6 +3676,7 @@ static int npuHaspSendRecordStrings(Tcb *tp, u8 *data, int len)
         }
     header[0] = 0;
     npuNetSend(tp, header, 1);
+
     return n + 1;
     }
 
@@ -3712,7 +3748,7 @@ static void npuHaspSendUplineData(Tcb *tp, u8 *data, int len)
     {
     NpuBuffer *bp;
 
-    bp = npuBipBufGet();
+    bp           = npuBipBufGet();
     bp->numBytes = len;
     memcpy(bp->data, data, bp->numBytes);
     npuBipQueueAppend(bp, &tp->scbp->uplineQ);
@@ -3880,6 +3916,7 @@ static u8 npuHaspTranslateSrcbToFe(u8 cc)
         case 1:
             fe = '1';
             break;
+
         case 2:
         case 3:
         case 4:
@@ -3887,9 +3924,11 @@ static u8 npuHaspTranslateSrcbToFe(u8 cc)
         case 6:
             fe = '3' + (6 - channel);
             break;
+
         case 12:
             fe = '2';
             break;
+
         default:
             fe = ' ';
             break;
@@ -3902,18 +3941,22 @@ static u8 npuHaspTranslateSrcbToFe(u8 cc)
         case 0:
             fe = '+';
             break;
+
         case 1:
         default:
             fe = ' ';
             break;
+
         case 2:
             fe = '0';
             break;
+
         case 3:
             fe = '-';
             break;
             }
         }
+
     return asciiToEbcdic[fe];
     }
 
@@ -3931,7 +3974,7 @@ static void npuHaspTransmitQueuedBlocks(Tcb *tp)
     NpuBuffer *bp;
     Scb       *scbp;
 
-    if (tp != NULL && tp->state == StTermConnected)
+    if ((tp != NULL) && (tp->state == StTermConnected))
         {
         scbp = tp->scbp;
         while (tp->uplineBlockLimit > 0
@@ -3985,7 +4028,7 @@ static int npuHaspAppendOutput(Pcb *pcbp, u8 *data, int len)
         *dp++ = *data++;
         }
 
-    return dp - start;
+    return (int)(dp - start);
     }
 
 /*--------------------------------------------------------------------------

--- a/npu_hip.c
+++ b/npu_hip.c
@@ -484,7 +484,7 @@ static FcStatus npuHipFunc(PpWord funcCode)
 
     case FcNpuInCouplerStatus:
         switch (hipState)
-        {
+            {
         case StHipInit:
             if (initCount > 0)
                 {
@@ -526,7 +526,7 @@ static FcStatus npuHipFunc(PpWord funcCode)
 
         default:
             break;
-        }
+            }
 
         break;
 
@@ -742,7 +742,7 @@ static void npuHipIo(void)
             activeChannel->full = FALSE;
 
             switch (orderType)
-            {
+                {
             case OrdOutServiceMsg:
                 npuBipNotifyServiceMessage();
                 break;
@@ -775,7 +775,7 @@ static void npuHipIo(void)
                 */
                 npuBipRetryInput();
                 break;
-            }
+                }
             }
 
         break;

--- a/npu_hip.c
+++ b/npu_hip.c
@@ -242,7 +242,7 @@ void npuInit(u8 eqNo, u8 unitNo, u8 channelNo, char *deviceName)
     */
     if (npuSw != SwUndefined)
         {
-        fprintf(stderr, "(cci_hip) CCP and CCI devices are mutually exclusive\n");
+        logDtError(LogErrorLocation, "(cci_hip) CCP and CCI devices are mutually exclusive\n");
         exit(1);
         }
     npuSw = SwCCP;
@@ -264,7 +264,7 @@ void npuInit(u8 eqNo, u8 unitNo, u8 channelNo, char *deviceName)
     npu = calloc(1, sizeof(NpuParam));
     if (npu == NULL)
         {
-        fprintf(stderr, "(npu_hip) Failed to allocate npu context block\n");
+        logDtError(LogErrorLocation, "(npu_hip) Failed to allocate npu context block\n");
         exit(1);
         }
 

--- a/npu_lip.c
+++ b/npu_lip.c
@@ -42,7 +42,7 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
-#endif 
+#endif
 
 
 #include "const.h"
@@ -208,7 +208,7 @@ void npuLipPresetPcb(Pcb *pcbp)
         npuLipLog = fopen("liplog.txt", "wt");
         if (npuLipLog == NULL)
             {
-            fprintf(stderr, "liplog.txt - aborting\n");
+            logDtError(LogErrorLocation, "liplog.txt - aborting\n");
             exit(1);
             }
         npuLipLogFlush(); // initialize log buffer
@@ -318,8 +318,8 @@ void npuLipProcessUplineData(Pcb *pcbp)
                                              | pcbp->inputData[pcbp->controls.lip.inputIndex++];
             if (pcbp->controls.lip.blockLength > MaxBuffer)
                 {
-                fprintf(stderr, "(npu_lip) Invalid block length %d received from %s\n",
-                        pcbp->controls.lip.blockLength, pcbp->ncbp->hostName);
+                logDtError(LogErrorLocation, "(npu_lip) Invalid block length %d received from %s\n",
+                           pcbp->controls.lip.blockLength, pcbp->ncbp->hostName);
 #if DEBUG
                 fprintf(npuLipLog, "Port %02x: invalid block length %d received from %s\n", pcbp->claPort,
                         pcbp->controls.lip.blockLength, pcbp->ncbp->hostName);
@@ -338,7 +338,7 @@ void npuLipProcessUplineData(Pcb *pcbp)
             break;
 
         case StTrunkRcvBlockContent:
-            stagingCount   = pcbp->controls.lip.stagingBufPtr - pcbp->controls.lip.stagingBuf;
+            stagingCount   = (int)(pcbp->controls.lip.stagingBufPtr - pcbp->controls.lip.stagingBuf);
             inputRemainder = pcbp->inputCount - pcbp->controls.lip.inputIndex;
             n = (stagingCount + inputRemainder <= pcbp->controls.lip.blockLength)
                 ? inputRemainder : pcbp->controls.lip.blockLength - stagingCount;
@@ -472,7 +472,7 @@ void npuLipProcessDownlineData(NpuBuffer *bp)
                 return;
                 }
             }
-        fprintf(stderr, "(npu_lip) Block received for unknown or disconnected node %02x\n", dn);
+        logDtError(LogErrorLocation, "(npu_lip) Block received for unknown or disconnected node %02x\n", dn);
 #if DEBUG
         fprintf(npuLipLog, "Block received for unknown or disconnected node: %02x\n", dn);
 #endif
@@ -580,7 +580,7 @@ static bool npuLipProcessConnectRequest(Pcb *pcbp)
     **  Parse peer name.
     */
     token = strtok(NULL, " \r\n");
-    len   = strlen(token);
+    len   = (int)strlen(token);
     if ((token == NULL) || (len >= sizeof(hostID)))
         {
         return FALSE;
@@ -845,7 +845,7 @@ static bool npuLipActivateTrunk(Pcb *pcbp)
     *mp++ = 0x01;                           // SFC: Logical link
     *mp++ = 0x0f;                           // NS=1, CS=1, Regulation level=3
 
-    bp->numBytes = mp - bp->data;
+    bp->numBytes = (int)(mp - bp->data);
 
     npuBipRequestUplineTransfer(bp);
 
@@ -887,7 +887,7 @@ static bool npuLipDeactivateTrunk(Pcb *pcbp)
     *mp++ = 0x01;                           // SFC: Logical link
     *mp++ = 0x0c;                           // NS=1, CS=1, Regulation level=0
 
-    bp->numBytes = mp - bp->data;
+    bp->numBytes = (int)(mp - bp->data);
 
     npuBipRequestUplineTransfer(bp);
 
@@ -1033,8 +1033,8 @@ static void npuLipSendQueuedData(Pcb *pcbp)
             if (n < 0)
                 {
                 npuBipBufRelease(bp);
-                fprintf(stderr, "(npu_lip) Failed to send whole block length to %s\n",
-                        pcbp->ncbp->hostName);
+                logDtError(LogErrorLocation, "(npu_lip) Failed to send whole block length to %s\n",
+                           pcbp->ncbp->hostName);
                 npuLipNotifyNetDisconnect(pcbp);
 
                 return;

--- a/npu_net.c
+++ b/npu_net.c
@@ -1095,7 +1095,7 @@ static int npuNetCreateConnections(void)
         // fall through
         case ConnTypeRevHasp:
             switch (ncbp->state)
-            {
+                {
             case StConnInit:
                 if (currentTime < ncbp->nextConnectionAttempt)
                     {
@@ -1170,7 +1170,7 @@ static int npuNetCreateConnections(void)
 
             default:
                 break;
-            }
+                }
             break;
 
         default:

--- a/npu_net.c
+++ b/npu_net.c
@@ -37,7 +37,7 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
-#endif 
+#endif
 
 
 #include "const.h"
@@ -68,7 +68,7 @@
 **  Private Constants
 **  -----------------
 */
-#define MaxClaPorts       128
+#define MaxClaPorts       255
 #define NamStartupTime    30
 
 /*
@@ -120,10 +120,10 @@ u8   npuNetMaxCN      = 0;
 **  Private Variables
 **  -----------------
 */
-static char abortMsg[]        = "\r\nConnection aborted\r\n";
-static char connectingMsg[]   = "\r\nConnecting to host - please wait ...";
-static char connectedMsg[]    = "\r\nConnected\r\n";
-static char *connStates[]     =
+static char abortMsg[]      = "\r\nConnection aborted\r\n";
+static char connectingMsg[] = "\r\nConnecting to host - please wait ...";
+static char connectedMsg[]  = "\r\nConnected\r\n";
+static char *connStates[]   =
     {
     //
     // Indexed by connection state
@@ -133,7 +133,7 @@ static char *connStates[]     =
     "connected",     // StConnConnected
     "busy"           // StConnBusy
     };
-static char *connTypes[]      =
+static char *connTypes[] =
     {
     //
     // Indexed by connection type
@@ -147,9 +147,9 @@ static char *connTypes[]      =
     "nje",    // ConnTypeNje
     "trunk"   // ConnTypeTrunk
     };
-static char networkDownMsg[]  = "\r\nNetwork going down - connection aborted\r\n";
-static char notReadyMsg[]     = "\r\nHost not ready to accept connections - please try again later.\r\n";
-static char noPortsAvailMsg[] = "\r\nNo free ports available - please try again later.\r\n";
+static char networkDownMsg[]      = "\r\nNetwork going down - connection aborted\r\n";
+static char notReadyMsg[]         = "\r\nHost not ready to accept connections - please try again later.\r\n";
+static char noPortsAvailMsg[]     = "\r\nNo free ports available - please try again later.\r\n";
 static char tcbNotConfiguredMsg[] = "\r\nCould not configure tcb - please try again later.\r\n";
 
 static Pcb  pcbs[MaxClaPorts];
@@ -388,11 +388,14 @@ void npuNetCloseConnection(Pcb *pcbp)
 
     if (pcbp != NULL)
         {
-        if (pcbp->connFd > 0) netCloseConnection(pcbp->connFd);
+        if (pcbp->connFd > 0)
+            {
+            netCloseConnection(pcbp->connFd);
+            }
         ncbp = pcbp->ncbp;
         if (ncbp != NULL)
             {
-            if (pcbp->connFd == ncbp->connFd || ncbp->state == StConnBusy)
+            if ((pcbp->connFd == ncbp->connFd) || (ncbp->state == StConnBusy))
                 {
                 ncbp->state = StConnInit;
                 ncbp->nextConnectionAttempt = getSeconds() + (time_t)ConnectionRetryInterval;
@@ -536,7 +539,7 @@ void npuNetReset(void)
             if ((ncbp != NULL) && (ncbp->connType != ConnTypePterm)
                 && (tp->deviceType == DtCONSOLE))
                 {
-                npuNetSendConsoleMsg(pcbp->connFd, ncbp->connType, networkDownMsg);
+                npuNetSendConsoleMsg((int)pcbp->connFd, ncbp->connType, networkDownMsg);
                 }
             npuNetCloseConnection(pcbp);
             tp->state = StTermIdle;
@@ -566,7 +569,7 @@ void npuNetConnected(Tcb *tp)
     {
     if (tp->deviceType == DtCONSOLE)
         {
-        npuNetSendConsoleMsg(tp->pcbp->connFd, tp->pcbp->ncbp->connType, connectedMsg);
+        npuNetSendConsoleMsg((int)tp->pcbp->connFd, tp->pcbp->ncbp->connType, connectedMsg);
         }
     }
 
@@ -676,11 +679,11 @@ void npuNetCheckStatus(void)
             }
         if (pcbp->cciWaitForTcb)
             {
-            if (getSeconds() - pcbp->cciTcbWaitStart > CciWaitForTcbTimeout) 
+            if (getSeconds() - pcbp->cciTcbWaitStart > CciWaitForTcbTimeout)
                 {
-                npuNetSendConsoleMsg(pcbp->connFd, pcbp->ncbp->connType, tcbNotConfiguredMsg);
+                npuNetSendConsoleMsg((int)pcbp->connFd, pcbp->ncbp->connType, tcbNotConfiguredMsg);
                 netCloseConnection(pcbp->connFd);
-                pcbp->connFd = 0;
+                pcbp->connFd      = 0;
                 pcbp->ncbp->state = StConnInit;
                 }
             continue;
@@ -692,7 +695,7 @@ void npuNetCheckStatus(void)
         FD_ZERO(&readFds);
         FD_ZERO(&writeFds);
         FD_SET(pcbp->connFd, &readFds);
-        readySockets = select(pcbp->connFd + 1, &readFds, NULL, NULL, &timeout);
+        readySockets = select((int)(pcbp->connFd + 1), &readFds, NULL, NULL, &timeout);
 
         if ((readySockets > 0) && FD_ISSET(pcbp->connFd, &readFds))
             {
@@ -712,7 +715,7 @@ void npuNetCheckStatus(void)
             {
             FD_ZERO(&writeFds);
             FD_SET(pcbp->connFd, &writeFds);
-            readySockets = select(pcbp->connFd + 1, NULL, &writeFds, NULL, &timeout);
+            readySockets = select((int)(pcbp->connFd + 1), NULL, &writeFds, NULL, &timeout);
             if ((readySockets > 0) && FD_ISSET(pcbp->connFd, &writeFds))
                 {
                 /*
@@ -742,18 +745,17 @@ void npuNetCheckStatus(void)
 **------------------------------------------------------------------------*/
 void npuNetShowStatus()
     {
-    u8       channelNo;
-    char     chEqStr[10];
+    u8      channelNo;
+    char    chEqStr[10];
     DevSlot *dp;
-    char     *dts;
-    u8       eqNo;
-    int      i;
-    u32      ipAddr;
-    Ncb      *ncbp;
-    Pcb      *pcbp;
-    char     peerAddress[24];
-    u16      port;
-    char     outBuf[200];
+    char    *dts;
+    int     i;
+    u32     ipAddr;
+    Ncb     *ncbp;
+    Pcb     *pcbp;
+    char    peerAddress[24];
+    u16     port;
+    char    outBuf[200];
 
     dp = NULL;
     for (channelNo = 0; channelNo < MaxChannels; channelNo++)
@@ -777,9 +779,12 @@ void npuNetShowStatus()
             break;
             }
         }
-    if (dp == NULL) return;
+    if (dp == NULL)
+        {
+        return;
+        }
 
-    sprintf(chEqStr, "C%02o E%02o",  dp->channel->id, dp->eqNo);
+    sprintf(chEqStr, "C%02o E%02o", dp->channel->id, dp->eqNo);
     for (i = 0; i < numNcbs; i++)
         {
         ncbp = &ncbs[i];
@@ -794,8 +799,8 @@ void npuNetShowStatus()
         case ConnTypeTrunk:
             if (ncbp->lstnFd > 0)
                 {
-                sprintf(outBuf, "    >   %-8s %-7s     "FMTNETSTATUS"\n", dts, chEqStr, netGetLocalTcpAddress(ncbp->lstnFd), "",
-                    connTypes[ncbp->connType], "listening");
+                sprintf(outBuf, "    >   %-8s %-7s     "FMTNETSTATUS "\n", dts, chEqStr, netGetLocalTcpAddress(ncbp->lstnFd), "",
+                        connTypes[ncbp->connType], "listening");
                 opDisplay(outBuf);
                 chEqStr[0] = '\0';
                 }
@@ -805,22 +810,22 @@ void npuNetShowStatus()
             ipAddr = ntohl(ncbp->hostAddr.sin_addr.s_addr);
             port   = ntohs(ncbp->hostAddr.sin_port);
             sprintf(peerAddress, "%d.%d.%d.%d:%d",
-              (ipAddr >> 24) & 0xff,
-              (ipAddr >> 16) & 0xff,
-              (ipAddr >>  8) & 0xff,
-              ipAddr         & 0xff,
-              port);
+                    (ipAddr >> 24) & 0xff,
+                    (ipAddr >> 16) & 0xff,
+                    (ipAddr >> 8) & 0xff,
+                    ipAddr & 0xff,
+                    port);
             if (ncbp->state == StConnConnecting)
                 {
-                sprintf(outBuf, "    >   %-8s %-7s     "FMTNETSTATUS"\n", dts, chEqStr, netGetLocalTcpAddress(ncbp->connFd),
-                    peerAddress, connTypes[ncbp->connType], "connecting");
+                sprintf(outBuf, "    >   %-8s %-7s     "FMTNETSTATUS "\n", dts, chEqStr, netGetLocalTcpAddress(ncbp->connFd),
+                        peerAddress, connTypes[ncbp->connType], "connecting");
                 opDisplay(outBuf);
                 chEqStr[0] = '\0';
                 }
             else if (ncbp->state != StConnConnected)
                 {
-                sprintf(outBuf, "    >   %-8s %-7s     "FMTNETSTATUS"\n", dts, chEqStr, ipAddress, peerAddress,
-                    connTypes[ncbp->connType], "disconnected");
+                sprintf(outBuf, "    >   %-8s %-7s     "FMTNETSTATUS "\n", dts, chEqStr, ipAddress, peerAddress,
+                        connTypes[ncbp->connType], "disconnected");
                 opDisplay(outBuf);
                 chEqStr[0] = '\0';
                 }
@@ -833,10 +838,10 @@ void npuNetShowStatus()
     for (i = 0; i < MaxClaPorts; i++)
         {
         pcbp = &pcbs[i];
-        if (pcbp->ncbp != NULL && pcbp->connFd > 0)
+        if ((pcbp->ncbp != NULL) && (pcbp->connFd > 0))
             {
-            sprintf(outBuf, "    >   %-8s %-7s P%02x "FMTNETSTATUS"\n", dts, chEqStr, pcbp->claPort, netGetLocalTcpAddress(pcbp->connFd),
-                netGetPeerTcpAddress(pcbp->connFd), connTypes[pcbp->ncbp->connType], connStates[pcbp->ncbp->state]),
+            sprintf(outBuf, "    >   %-8s %-7s P%02x "FMTNETSTATUS "\n", dts, chEqStr, pcbp->claPort, netGetLocalTcpAddress(pcbp->connFd),
+                    netGetPeerTcpAddress(pcbp->connFd), connTypes[pcbp->ncbp->connType], connStates[pcbp->ncbp->state]),
             opDisplay(outBuf);
             chEqStr[0] = '\0';
             }
@@ -934,7 +939,7 @@ static void npuNetSendConsoleMsg(int connFd, int connType, char *msg)
     case ConnTypePterm:
     case ConnTypeRs232:
     case ConnTypeTelnet:
-        send(connFd, msg, strlen(msg), 0);
+        send(connFd, msg, (int)strlen(msg), 0);
         break;
 
     case ConnTypeHasp:
@@ -959,16 +964,16 @@ static void npuNetSendConsoleMsg(int connFd, int connType, char *msg)
 static int npuNetAcceptConnections(fd_set *selectFds, int maxFd)
     {
 #if defined(_WIN32)
-    SOCKET             acceptFd;
+    SOCKET acceptFd;
 #else
-    int                acceptFd;
+    int acceptFd;
 #endif
-    fd_set             acceptFds;
-    int                i;
-    int                n;
-    Ncb                *ncbp;
-    int                rc;
-    struct timeval     timeout;
+    fd_set         acceptFds;
+    int            i;
+    int            n;
+    Ncb            *ncbp;
+    int            rc;
+    struct timeval timeout;
 
     timeout.tv_sec  = 1;
     timeout.tv_usec = 0;
@@ -978,7 +983,7 @@ static int npuNetAcceptConnections(fd_set *selectFds, int maxFd)
     rc = select(maxFd + 1, &acceptFds, NULL, NULL, &timeout);
     if (rc < 0)
         {
-        fprintf(stderr, "(npu_net) select returned unexpected %d\n", rc);
+        logDtError(LogErrorLocation, "(npu_net) select returned unexpected %d\n", rc);
         sleepMsec(1000);
         }
     else if (rc < 1)
@@ -1006,9 +1011,9 @@ static int npuNetAcceptConnections(fd_set *selectFds, int maxFd)
                 {
                 acceptFd = netAcceptConnection(ncbp->lstnFd);
 #if defined(_WIN32)
-                if (acceptFd != INVALID_SOCKET && npuNetProcessNewConnection(acceptFd, ncbp, TRUE))
+                if ((acceptFd != INVALID_SOCKET) && npuNetProcessNewConnection((int)acceptFd, ncbp, TRUE))
 #else
-                if (acceptFd >= 0 && npuNetProcessNewConnection(acceptFd, ncbp, TRUE))
+                if ((acceptFd >= 0) && npuNetProcessNewConnection(acceptFd, ncbp, TRUE))
 #endif
                     {
                     n += 1;
@@ -1020,7 +1025,7 @@ static int npuNetAcceptConnections(fd_set *selectFds, int maxFd)
             break;
 
         default:
-            fprintf(stderr, "(npu_net) Invalid connection type: %u\n", ncbp->connType);
+            logDtError(LogErrorLocation, "(npu_net) Invalid connection type: %u\n", ncbp->connType);
             break;
             }
         }
@@ -1038,11 +1043,12 @@ static int npuNetAcceptConnections(fd_set *selectFds, int maxFd)
 **------------------------------------------------------------------------*/
 static int npuNetCreateConnections(void)
     {
-    time_t         currentTime;
+    time_t currentTime;
+
 #if defined(_WIN32)
-    SOCKET         fd;
+    SOCKET fd;
 #else
-    int            fd;
+    int fd;
 #endif
     int            i;
     int            n;
@@ -1081,8 +1087,12 @@ static int npuNetCreateConnections(void)
 
         case ConnTypeTrunk:
         case ConnTypeNje:
-            if (ncbp->hostAddr.sin_port == 0) continue; // listen-only
-            // fall through
+            if (ncbp->hostAddr.sin_port == 0)
+                {
+                continue;                               // listen-only
+                }
+
+        // fall through
         case ConnTypeRevHasp:
             switch (ncbp->state)
             {
@@ -1115,10 +1125,10 @@ static int npuNetCreateConnections(void)
                 FD_SET(ncbp->connFd, &selectFds);
                 timeout.tv_sec  = 0;
                 timeout.tv_usec = 0;
-                rc = select(ncbp->connFd + 1, NULL, &selectFds, NULL, &timeout);
+                rc = select((int)(ncbp->connFd + 1), NULL, &selectFds, NULL, &timeout);
                 if (rc < 0)
                     {
-                    fprintf(stderr, "NET: select returned unexpected %d\n", rc);
+                    logDtError(LogErrorLocation, "NET: select returned unexpected %d\n", rc);
                     sleepMsec(1000);
                     }
                 else if (rc > 0)
@@ -1137,7 +1147,7 @@ static int npuNetCreateConnections(void)
                         else
                             {
                             npuLogMessage("(npu_net) Connected to host: %s:%u", ncbp->hostName, ncbp->tcpPort);
-                            if (npuNetProcessNewConnection(ncbp->connFd, ncbp, FALSE))
+                            if (npuNetProcessNewConnection((int)ncbp->connFd, ncbp, FALSE))
                                 {
                                 n += 1;
                                 }
@@ -1164,7 +1174,7 @@ static int npuNetCreateConnections(void)
             break;
 
         default:
-            fprintf(stderr, "(npu_net) Invalid connection type: %u\n", ncbp->connType);
+            logDtError(LogErrorLocation, "(npu_net) Invalid connection type: %u\n", ncbp->connType);
             break;
             }
         }
@@ -1190,19 +1200,20 @@ static bool npuNetCreateListeningSocket(Ncb *ncbp)
     sd = netCreateListener(ncbp->tcpPort);
     if (sd == INVALID_SOCKET)
 #else
-    int    sd;
+    int sd;
 
     sd = netCreateListener(ncbp->tcpPort);
     if (sd == -1)
 #endif
         {
-        fprintf(stderr, "(npu_net) Can't create listener for port %d\n", ncbp->tcpPort);
+        logDtError(LogErrorLocation, "(npu_net) Can't create listener for port %d\n", ncbp->tcpPort);
+
         return FALSE;
         }
     ncbp->lstnFd = sd;
 
 #if DEBUG >= 2
-    fprintf(stderr, "(npu_net) created listener for port %d\n", ncbp->tcpPort);
+    logDtError(LogErrorLocation, "(npu_net) created listener for port %d\n", ncbp->tcpPort);
 #endif
 
 
@@ -1237,7 +1248,7 @@ static void npuNetCreateThread(void)
 
     if (hThread == NULL)
         {
-        fprintf(stderr, "Failed to create npuNet thread\n");
+        logDtError(LogErrorLocation, "Failed to create npuNet thread\n");
         exit(1);
         }
 #else
@@ -1252,7 +1263,7 @@ static void npuNetCreateThread(void)
     rc = pthread_create(&thread, &attr, npuNetThread, NULL);
     if (rc < 0)
         {
-        fprintf(stderr, "Failed to create npuNet thread\n");
+        logDtError(LogErrorLocation, "Failed to create npuNet thread\n");
         exit(1);
         }
 #endif
@@ -1287,12 +1298,12 @@ static void *npuNetThread(void *param)
     FD_ZERO(&listenFds);
 
 #if DEBUG >= 2
-    fprintf(stderr, "npuNetThread has %d Ncbs to check\n", numNcbs);
+    logDtError(LogErrorLocation, "npuNetThread has %d Ncbs to check\n", numNcbs);
     for (i = 0; i < numNcbs; i++)
         {
         ncbp = &ncbs[i];
-	fprintf(stderr, "npuNetThread .. (%d), type %d, port %d\n", i, ncbp->connType, ncbp->tcpPort);
-	}
+        logDtError(LogErrorLocation, "npuNetThread .. (%d), type %d, port %d\n", i, ncbp->connType, ncbp->tcpPort);
+        }
 #endif
 
     /*
@@ -1303,7 +1314,7 @@ static void *npuNetThread(void *param)
         {
         ncbp = &ncbs[i];
 #if DEBUG >= 2
-	fprintf(stderr, "npuNetThread checking Ncb %d, type %d, port %d\n", i, ncbp->connType, ncbp->tcpPort);
+        logDtError(LogErrorLocation, "npuNetThread checking Ncb %d, type %d, port %d\n", i, ncbp->connType, ncbp->tcpPort);
 #endif
         switch (ncbp->connType)
             {
@@ -1354,14 +1365,14 @@ static void *npuNetThread(void *param)
             break;
 
         default:
-            fprintf(stderr, "(npu_net) Invalid connection type: %u\n", ncbp->connType);
+            logDtError(LogErrorLocation, "(npu_net) Invalid connection type: %u\n", ncbp->connType);
             break;
             }
         }
 
     for ( ; ;)
         {
-        npuNetAcceptConnections(&listenFds, maxFd);
+        npuNetAcceptConnections(&listenFds, (int)maxFd);
         npuNetCreateConnections();
         }
 
@@ -1434,7 +1445,7 @@ static bool npuNetProcessNewConnection(int connFd, Ncb *ncbp, bool isPassive)
     limit = ncbp->claPort + ncbp->numPorts;
     for (i = ncbp->claPort; i < limit; i++)
         {
-        if (pcbs[i].connFd < 1 && (! pcbs[i].cciIsDisabled))
+        if ((pcbs[i].connFd < 1) && (!pcbs[i].cciIsDisabled))
             {
             pcbp = &pcbs[i];
             break;

--- a/npu_nje.c
+++ b/npu_nje.c
@@ -694,7 +694,7 @@ void npuNjeProcessUplineData(Pcb *pcbp)
                     {
                     status = npuNjeUploadBlock(pcbp, pcbp->controls.nje.inputBuf, size, &rcb, &srcb);
                     switch (status)
-                    {
+                        {
                     case NjeStatusSOH_ENQ:
                         if (npuNjeSend(pcbp, DLE_ACK0, sizeof(DLE_ACK0)) == sizeof(DLE_ACK0))
                             {
@@ -755,7 +755,7 @@ void npuNjeProcessUplineData(Pcb *pcbp)
                         npuNjeCloseConnection(pcbp);
                         dp = limit;
                         break;
-                    }
+                        }
                     }
                 else
                     {
@@ -2206,7 +2206,7 @@ static int npuNjeUploadBlock(Pcb *pcbp, u8 *blkp, int size, u8 *rcb, u8 *srcb)
             */
             case 0xf0: // general control record
                 switch (*srcb)
-                {
+                    {
                 case SRCB_Signoff:
                     recLen = 0;
                     break;
@@ -2238,7 +2238,7 @@ static int npuNjeUploadBlock(Pcb *pcbp, u8 *blkp, int size, u8 *rcb, u8 *srcb)
                     return NjeErrProtocolError;
 
                     break;
-                }
+                    }
                 *obp++ = recLen;
                 *obp++ = *rcb;
                 *obp++ = *srcb;
@@ -2339,7 +2339,7 @@ static int npuNjeUploadBlock(Pcb *pcbp, u8 *blkp, int size, u8 *rcb, u8 *srcb)
                     {
                     scb = *ibp++;
                     switch (scb & 0xc0)
-                    {
+                        {
                     case 0x40: // terminate stream transmission
                         break;
 
@@ -2363,7 +2363,7 @@ static int npuNjeUploadBlock(Pcb *pcbp, u8 *blkp, int size, u8 *rcb, u8 *srcb)
                         npuBipBufRelease(bp);
 
                         return NjeErrBadSCB;
-                    }
+                        }
                     }
                 if (ibp >= ibLimit)
                     {
@@ -2405,7 +2405,7 @@ static int npuNjeUploadBlock(Pcb *pcbp, u8 *blkp, int size, u8 *rcb, u8 *srcb)
                     {
                     scb = *ibp++;
                     switch (scb & 0xc0)
-                    {
+                        {
                     case 0x80: // compressed string
                         len = scb & 0x1f;
                         if ((scb & 0x20) == 0x20)
@@ -2438,7 +2438,7 @@ static int npuNjeUploadBlock(Pcb *pcbp, u8 *blkp, int size, u8 *rcb, u8 *srcb)
 
                     default:
                         break;
-                    }
+                        }
                     }
                 ibp += 1; // advance past end of record SCB (0x00)
 

--- a/npu_tip.c
+++ b/npu_tip.c
@@ -439,7 +439,7 @@ void npuTipProcessBuffer(NpuBuffer *bp, int priority)
 
     case BtHTCMD:
         switch (block[BlkOffPfc])
-        {
+            {
         case PfcCTRL:
             if (block[BlkOffSfc] == SfcCHAR)
                 {
@@ -522,7 +522,7 @@ void npuTipProcessBuffer(NpuBuffer *bp, int priority)
             fputs("Unrecognized TIP command\n", npuTipLog);
 #endif
             break;
-        }
+            }
 
         /*
         **  Acknowledge any command (although most are ignored).
@@ -539,7 +539,7 @@ void npuTipProcessBuffer(NpuBuffer *bp, int priority)
             {
             last = (block[BlkOffBTBSN] & BlkMaskBT) == BtHTMSG;
             switch (tp->tipType)
-            {
+                {
             case TtASYNC:
                 npuAsyncProcessDownlineData(tp, bp, last);
                 break;
@@ -561,7 +561,7 @@ void npuTipProcessBuffer(NpuBuffer *bp, int priority)
                 blockAck[BlkOffBTBSN] |= block[BlkOffBTBSN] & (BlkMaskBSN << BlkShiftBSN);
                 npuBipRequestUplineCanned(blockAck, sizeof(blockAck));
                 break;
-            }
+                }
             }
         else
             {
@@ -675,7 +675,7 @@ void npuTipSetupTerminalClass(Tcb *tp, u8 tc)
 
     default:
         switch (tp->tipType)
-        {
+            {
         default:
         case TtASYNC:
             tp->params = defaultTc3;
@@ -692,7 +692,7 @@ void npuTipSetupTerminalClass(Tcb *tp, u8 tc)
         case TtTT13:
             tp->params = defaultTc29;
             break;
-        }
+            }
         }
     }
 

--- a/npu_tip.c
+++ b/npu_tip.c
@@ -40,7 +40,7 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
-#endif 
+#endif
 
 
 #include "const.h"
@@ -301,7 +301,7 @@ void npuTipInit(void)
     npuTipLog = fopen("tiplog.txt", "wt");
     if (npuTipLog == NULL)
         {
-        fprintf(stderr, "tiplog.txt - aborting\n");
+        logDtError(LogErrorLocation, "tiplog.txt - aborting\n");
         exit(1);
         }
 #endif
@@ -408,16 +408,16 @@ void npuTipProcessBuffer(NpuBuffer *bp, int priority)
         return;
         }
 #if DEBUG
-    {
-    int i;
-    fprintf(npuTipLog, "Connection %u received block type %02x, PFC %02x, SFC %02x\n   ",
-            cn, block[BlkOffBTBSN] & BlkMaskBT, block[BlkOffPfc], block[BlkOffSfc]);
-    for (i = 0; i < bp->numBytes; i++)
         {
-        fprintf(npuTipLog, " %02x", bp->data[i]);
+        int i;
+        fprintf(npuTipLog, "Connection %u received block type %02x, PFC %02x, SFC %02x\n   ",
+                cn, block[BlkOffBTBSN] & BlkMaskBT, block[BlkOffPfc], block[BlkOffSfc]);
+        for (i = 0; i < bp->numBytes; i++)
+            {
+            fprintf(npuTipLog, " %02x", bp->data[i]);
+            }
+        fputs("\n", npuTipLog);
         }
-    fputs("\n", npuTipLog);
-    }
 #endif
 
     switch (block[BlkOffBTBSN] & BlkMaskBT)
@@ -439,7 +439,7 @@ void npuTipProcessBuffer(NpuBuffer *bp, int priority)
 
     case BtHTCMD:
         switch (block[BlkOffPfc])
-            {
+        {
         case PfcCTRL:
             if (block[BlkOffSfc] == SfcCHAR)
                 {
@@ -554,8 +554,8 @@ void npuTipProcessBuffer(NpuBuffer *bp, int priority)
                 break;
 
             default:
-                fprintf(stderr, "(npu_tip) Downline data for unrecognized TIP type %u on connection %u\n",
-                        tp->tipType, tp->cn);
+                logDtError(LogErrorLocation, "Downline data for unrecognized TIP type %u on connection %u\n",
+                           tp->tipType, tp->cn);
                 blockAck[BlkOffCN]     = block[BlkOffCN];
                 blockAck[BlkOffBTBSN] &= BlkMaskBT;
                 blockAck[BlkOffBTBSN] |= block[BlkOffBTBSN] & (BlkMaskBSN << BlkShiftBSN);
@@ -578,7 +578,7 @@ void npuTipProcessBuffer(NpuBuffer *bp, int priority)
 
     case BtHTQBLK:
     case BtHTQMSG:
-        fprintf(stderr, "(npu_tip) Qualified block/message ignored, port=%02x\n", tp->pcbp->claPort);
+        logDtError(LogErrorLocation, "Qualified block/message ignored, port=%02x\n", tp->pcbp->claPort);
         break;
 
     case BtHTBACK:
@@ -1073,7 +1073,7 @@ void npuTipSendUserBreak(Tcb *tp, u8 bt)
     /*
     **  Send the ICMD.
     */
-    npuBipRequestUplineCanned(tp->inBuf, mp - tp->inBuf);
+    npuBipRequestUplineCanned(tp->inBuf, (int)(mp - tp->inBuf));
 
     /*
     **  Increment BSN.
@@ -1098,7 +1098,7 @@ void npuTipSendUserBreak(Tcb *tp, u8 bt)
     /*
     **  Send the BI/MARK.
     */
-    npuBipRequestUplineCanned(tp->inBuf, mp - tp->inBuf);
+    npuBipRequestUplineCanned(tp->inBuf, (int)(mp - tp->inBuf));
 
     /*
     **  Purge output and send back all acknowledgments.

--- a/operator.c
+++ b/operator.c
@@ -86,14 +86,14 @@ typedef struct opCmd
 
 typedef struct opCmdStackEntry
     {
-    int in;
-    int out;
+    int    in;
+    int    out;
 #if defined(_WIN32)
     SOCKET netConn;
 #else
-    int netConn;
+    int    netConn;
 #endif
-    char cwd[CwdPathSize];
+    char   cwd[CwdPathSize];
     } OpCmdStackEntry;
 
 typedef struct opNetTypeEntry
@@ -328,8 +328,8 @@ static int opListenHandle = 0;
 static int opListenPort = 0;
 
 static char opInBuf[256];
-static int  opInIdx  = 0;
-static char opOutBuf[MaxFSPath*2+128];
+static int  opInIdx = 0;
+static char opOutBuf[MaxFSPath * 2 + 128];
 static int  opOutIdx = 0;
 
 /*
@@ -373,7 +373,7 @@ void opDisplay(char *msg)
     ep = &opCmdStack[opCmdStackPtr];
     if (ep->netConn == 0)
         {
-        n = write(ep->out, msg, strlen(msg));
+        n = write(ep->out, msg, (int)strlen(msg));
         }
     else
         {
@@ -384,16 +384,22 @@ void opDisplay(char *msg)
         sp = cp = msg;
         while (*sp != '\0')
             {
-            while (*cp != '\0' && *cp != '\n') cp += 1;
+            while (*cp != '\0' && *cp != '\n')
+                {
+                cp += 1;
+                }
             if (*cp == '\n')
                 {
-                if (cp > sp) send(ep->netConn, sp, cp - sp, 0);
+                if (cp > sp)
+                    {
+                    send(ep->netConn, sp, (int)(cp - sp), 0);
+                    }
                 send(ep->netConn, "\r\n", 2, 0);
                 cp += 1;
                 }
             else if (cp > sp)
                 {
-                send(ep->netConn, sp, cp - sp, 0);
+                send(ep->netConn, sp, (int)(cp - sp), 0);
                 }
             sp = cp;
             }
@@ -417,6 +423,7 @@ bool opIsConsoleInput(void)
     OpCmdStackEntry *ep;
 
     ep = &opCmdStack[opCmdStackPtr];
+
     return ep->netConn == 0 && ep->in == fileno(stdin);
     }
 
@@ -510,19 +517,19 @@ static void opThread(void *param)
 static void *opThread(void *param)
 #endif
     {
-    OpCmd *cp;
-    char  cmd[256];
+    OpCmd           *cp;
+    char            cmd[256];
     OpCmdStackEntry *ep;
-    bool  isNetConnClosed;
-    int   len;
-    char  name[80];
-    int   newIn;
-    char  *params;
-    char  path[256];
-    char  *pos;
-    char  *sp;
+    bool            isNetConnClosed;
+    int             len;
+    char            name[80];
+    int             newIn;
+    char            *params;
+    char            path[256];
+    char            *pos;
+    char            *sp;
 
-    ep = &opCmdStack[opCmdStackPtr];
+    ep          = &opCmdStack[opCmdStackPtr];
     ep->in      = fileno(stdin);
     ep->out     = fileno(stdout);
     ep->netConn = 0;
@@ -548,10 +555,10 @@ static void *opThread(void *param)
     if (initOpenOperatorSection() == 1)
         {
         opCmdStackPtr += 1;
-        ep = &opCmdStack[opCmdStackPtr];
-        ep->in      = -1;
-        ep->out     = opCmdStack[opCmdStackPtr - 1].out;
-        ep->netConn = 0;
+        ep             = &opCmdStack[opCmdStackPtr];
+        ep->in         = -1;
+        ep->out        = opCmdStack[opCmdStackPtr - 1].out;
+        ep->netConn    = 0;
         strcpy(ep->cwd, opCmdStack[opCmdStackPtr - 1].cwd);
         }
 
@@ -563,7 +570,10 @@ static void *opThread(void *param)
         **  Wait for command input.
         */
         len = opReadLine(cmd, sizeof(cmd));
-        if (!emulationActive) break;
+        if (!emulationActive)
+            {
+            break;
+            }
         if (len <= 0)
             {
             if (opCmdStackPtr == 0)
@@ -595,12 +605,15 @@ static void *opThread(void *param)
                         }
                     opCmdStackPtr -= 1;
                     }
-                if (isNetConnClosed) opStartListening(opListenPort);
+                if (isNetConnClosed)
+                    {
+                    opStartListening(opListenPort);
+                    }
                 continue;
                 }
             }
 
-        if (ep->netConn == 0 && ep->in != fileno(stdin))
+        if ((ep->netConn == 0) && (ep->in != fileno(stdin)))
             {
             opDisplay(cmd);
             opDisplay("\n");
@@ -646,12 +659,12 @@ static void *opThread(void *param)
             if (newIn >= 0)
                 {
                 opCmdStackPtr += 1;
-                ep = &opCmdStack[opCmdStackPtr];
-                ep->in      = newIn;
-                ep->out     = opCmdStack[opCmdStackPtr - 1].out;
-                ep->netConn = 0;
-                pos  = strrchr(path, '/');
-                *pos = '\0';
+                ep             = &opCmdStack[opCmdStackPtr];
+                ep->in         = newIn;
+                ep->out        = opCmdStack[opCmdStackPtr - 1].out;
+                ep->netConn    = 0;
+                pos            = strrchr(path, '/');
+                *pos           = '\0';
                 strcpy(ep->cwd, path);
                 }
             else
@@ -717,25 +730,31 @@ static void opCmdPrompt(void)
 #if defined(_WIN32)
     SYSTEMTIME dt;
 
-    if (opCmdStackPtr != 0
-        && opCmdStack[opCmdStackPtr].netConn == 0
-        && opCmdStack[opCmdStackPtr].in != -1) return;
+    if ((opCmdStackPtr != 0)
+        && (opCmdStack[opCmdStackPtr].netConn == 0)
+        && (opCmdStack[opCmdStackPtr].in != -1))
+        {
+        return;
+        }
 
     GetLocalTime(&dt);
-    sprintf(opOutBuf, "\n%02d:%02d:%02d [%s] Operator> ", dt.wHour, dt.wMinute, dt.wSecond, displayName);
+    sprintf(opOutBuf, "\n%04d-%02d-%02d %02d:%02d:%02d \n[%s] Operator> ", dt.wYear, dt.wMonth, dt.wDay, dt.wHour, dt.wMinute, dt.wSecond, displayName);
 #else
     time_t    rawtime;
     struct tm *info;
     char      buffer[80];
 
-    if (opCmdStackPtr != 0
-        && opCmdStack[opCmdStackPtr].netConn == 0
-        && opCmdStack[opCmdStackPtr].in != -1) return;
+    if ((opCmdStackPtr != 0)
+        && (opCmdStack[opCmdStackPtr].netConn == 0)
+        && (opCmdStack[opCmdStackPtr].in != -1))
+        {
+        return;
+        }
 
     time(&rawtime);
     info = localtime(&rawtime);
-    strftime(buffer, 80, "%H:%M:%S", info);
-    sprintf(opOutBuf, "\n%s [%s] Operator> ", buffer, displayName);
+    strftime(buffer, 80, "%Y-%m-%d %H:%M:%S", info);
+    sprintf(opOutBuf, "\n%s \n[%s] Operator> ", buffer, displayName);
 #endif
     opDisplay(opOutBuf);
     }
@@ -754,27 +773,33 @@ static void opCmdPrompt(void)
 **------------------------------------------------------------------------*/
 static int opReadLine(char *buf, int size)
     {
-    char *bp;
-    char c;
+    char            *bp;
+    char            c;
     OpCmdStackEntry *ep;
-    int  err;
-    char *limit;
-    char *line;
-    int  lineNo;
-    int  n;
+    int             err;
+    char            *limit;
+    char            *line;
+    int             lineNo;
+    int             n;
 
     while (opActive)
         {
         sleepMsec(10);
         }
-    if (!emulationActive) return 0;
+    if (!emulationActive)
+        {
+        return 0;
+        }
 
-    bp = buf;
+    bp    = buf;
     limit = buf + (size - 2);
     opCmdPrompt();
     while (TRUE)
         {
-        if (!emulationActive) return 0;
+        if (!emulationActive)
+            {
+            return 0;
+            }
         if (opOutIdx >= opInIdx)
             {
             if (!opHasInput())
@@ -782,7 +807,7 @@ static int opReadLine(char *buf, int size)
                 sleepMsec(10);
                 continue;
                 }
-            ep = &opCmdStack[opCmdStackPtr];
+            ep       = &opCmdStack[opCmdStackPtr];
             opOutIdx = opInIdx = 0;
             if (ep->netConn != 0)
                 {
@@ -798,8 +823,11 @@ static int opReadLine(char *buf, int size)
                 else
                     {
                     strcpy(opInBuf, line);
-                    n = strlen(line);
-                    if (n == 0) continue;
+                    n = (int)strlen(line);
+                    if (n == 0)
+                        {
+                        continue;
+                        }
                     opInBuf[n++] = '\n';
                     }
                 }
@@ -818,7 +846,7 @@ static int opReadLine(char *buf, int size)
                         sleepMsec(10);
                         continue;
                         }
-                    fprintf(stderr, "Unexpected error while reading operator input: %d\n", err);
+                    logDtError(LogErrorLocation, "Unexpected error while reading operator input: %d\n", err);
 #else
                     if (errno == EWOULDBLOCK)
                         {
@@ -830,6 +858,7 @@ static int opReadLine(char *buf, int size)
                     netCloseConnection(ep->netConn);
                     opStartListening(opListenPort);
                     }
+
                 return -1;
                 }
             else if (n == 0)
@@ -837,7 +866,8 @@ static int opReadLine(char *buf, int size)
                 if (bp > buf)
                     {
                     *bp = '\0';
-                    return bp - buf;
+
+                    return (int)(bp - buf);
                     }
                 if (ep->netConn != 0)
                     {
@@ -848,6 +878,7 @@ static int opReadLine(char *buf, int size)
                     {
                     close(ep->in);
                     }
+
                 return 0;
                 }
             opInIdx = n;
@@ -858,11 +889,14 @@ static int opReadLine(char *buf, int size)
             if (c == '\n')
                 {
                 opPaused = FALSE;
-                if (bp > buf && *(bp - 1) == '\r') bp -= 1;
+                if ((bp > buf) && (*(bp - 1) == '\r'))
+                    {
+                    bp -= 1;
+                    }
                 *bp = '\0';
                 if (bp > buf)
                     {
-                    return bp - buf;
+                    return (int)(bp - buf);
                     }
                 else
                     {
@@ -870,7 +904,10 @@ static int opReadLine(char *buf, int size)
                     break;
                     }
                 }
-            if (bp < limit) *bp++ = c;
+            if (bp < limit)
+                {
+                *bp++ = c;
+                }
             }
         }
     }
@@ -894,9 +931,12 @@ static bool opHasInput()
     ep = &opCmdStack[opCmdStackPtr];
     if (ep->netConn == 0)
         {
-        if (ep->in == -1) return TRUE;
+        if (ep->in == -1)
+            {
+            return TRUE;
+            }
 #if defined(_WIN32)
-        if (ep->in == _fileno(stdin) && _isatty(_fileno(stdin)))
+        if ((ep->in == _fileno(stdin)) && _isatty(_fileno(stdin)))
             {
             if (kbhit())
                 {
@@ -905,12 +945,14 @@ static bool opHasInput()
             else
                 {
                 opAcceptConnection();
+
                 return FALSE;
                 }
             }
         else
             {
             opAcceptConnection();
+
             return TRUE;
             }
 #else
@@ -919,7 +961,7 @@ static bool opHasInput()
         }
     else
         {
-        fd = ep->netConn;
+        fd = (int)ep->netConn;
         }
 
     timeout.tv_sec  = 0;
@@ -935,6 +977,7 @@ static bool opHasInput()
     else
         {
         opAcceptConnection();
+
         return FALSE;
         }
     }
@@ -958,15 +1001,15 @@ static void opAcceptConnection(void)
     struct timeval     timeout;
 
 #if defined(_WIN32)
-    int fromLen;
+    int    fromLen;
     u_long blockEnable = 1;
 #else
     socklen_t fromLen;
 #endif
 
-    if (opListenHandle == 0
-        || opCmdStackPtr > 0
-        || opCmdStack[opCmdStackPtr].netConn != 0)
+    if ((opListenHandle == 0)
+        || (opCmdStackPtr > 0)
+        || (opCmdStack[opCmdStackPtr].netConn != 0))
         {
         return;
         }
@@ -977,22 +1020,23 @@ static void opAcceptConnection(void)
     FD_ZERO(&acceptFds);
     FD_SET(opListenHandle, &acceptFds);
 
-    n = select(opListenHandle + 1, &acceptFds, NULL, NULL, &timeout);
-    if (n <= 0 || !FD_ISSET(opListenHandle, &acceptFds))
+    n = select((int)(opListenHandle + 1), &acceptFds, NULL, NULL, &timeout);
+    if ((n <= 0) || !FD_ISSET(opListenHandle, &acceptFds))
         {
         return;
         }
     fromLen  = sizeof(from);
-    acceptFd = accept(opListenHandle, (struct sockaddr *)&from, &fromLen);
+    acceptFd = (int)accept(opListenHandle, (struct sockaddr *)&from, &fromLen);
     if (acceptFd >= 0)
         {
         if (opCmdStackPtr + 1 >= MaxCmdStkSize)
             {
             opDisplay("    > Too many nested operator input sources\n");
             netCloseConnection(acceptFd);
+
             return;
             }
-        setsockopt(acceptFd, SOL_SOCKET, SO_KEEPALIVE, (void*)&optEnable, sizeof(optEnable));
+        setsockopt(acceptFd, SOL_SOCKET, SO_KEEPALIVE, (void *)&optEnable, sizeof(optEnable));
 #if defined(_WIN32)
         ioctlsocket(acceptFd, FIONBIO, &blockEnable);
 #else
@@ -1001,7 +1045,7 @@ static void opAcceptConnection(void)
         opDisplay("\nOperator connection accepted\n");
         opCmdStackPtr += 1;
         netCloseConnection(opListenHandle);
-        opListenHandle                    = 0;
+        opListenHandle = 0;
         opCmdStack[opCmdStackPtr].netConn = acceptFd;
         opCmdStack[opCmdStackPtr].in      = 0;
         opCmdStack[opCmdStackPtr].out     = 0;
@@ -1084,13 +1128,19 @@ static char *opGetString(char *inStr, char *outStr, int outSize)
 **------------------------------------------------------------------------*/
 static bool opIsAbsolutePath(char *path)
     {
-    if (*path == '/') return TRUE;
+    if (*path == '/')
+        {
+        return TRUE;
+        }
 #if defined(_WIN32)
     if ((*(path + 1) == ':')
-        && (   (*path >= 'A' && *path <= 'Z')
-            || (*path >= 'a' && *path <= 'z'))) return TRUE;
-
+        && (((*path >= 'A') && (*path <= 'Z'))
+            || ((*path >= 'a') && (*path <= 'z'))))
+        {
+        return TRUE;
+        }
 #endif
+
     return FALSE;
     }
 
@@ -1260,7 +1310,7 @@ static void opCmdDumpCM(int fwa, int count)
     int    shiftCount;
     CpWord word;
 
-    if ((fwa < 0) || (count < 0) || (fwa + count > cpuMaxMemory))
+    if ((fwa < 0) || (count < 0) || ((u32)(fwa + count) > cpuMaxMemory))
         {
         opDisplay("    > Invalid CM address or count\n");
 
@@ -1290,7 +1340,7 @@ static void opCmdDumpEM(int fwa, int count)
     int    shiftCount;
     CpWord word;
 
-    if ((fwa < 0) || (count < 0) || (fwa + count > extMaxMemory))
+    if ((fwa < 0) || (count < 0) || ((u32)(fwa + count) > extMaxMemory))
         {
         opDisplay("    > Invalid EM address or count\n");
 
@@ -1458,6 +1508,7 @@ static void opCmdEnterKeys(bool help, char *cmdParams)
                 {
                 sprintf(opOutBuf, "Unrecognized keyword: %%%s%%\n", kp);
                 opDisplay(opOutBuf);
+
                 return;
                 }
             }
@@ -1469,6 +1520,7 @@ static void opCmdEnterKeys(bool help, char *cmdParams)
     if (bp > limit)
         {
         opDisplay("Key sequence is too long\n");
+
         return;
         }
     *bp = '\0';
@@ -1715,7 +1767,10 @@ static void opHelpSetOperatorPort(void)
 **------------------------------------------------------------------------*/
 static int opStartListening(int port)
     {
-    if (port <= 0) return FALSE;
+    if (port <= 0)
+        {
+        return FALSE;
+        }
 
     /*
     **  Start listening for new connections
@@ -1730,6 +1785,7 @@ static int opStartListening(int port)
         sprintf(opOutBuf, "    > Failed to listen on port %d\n", port);
         opDisplay(opOutBuf);
         opListenHandle = 0;
+
         return FALSE;
         }
 
@@ -2044,6 +2100,7 @@ void opCmdLoadCards(bool help, char *cmdParams)
         {
         sprintf(opOutBuf, "    > Invalid channel no %02o. (must be 0 to %02o) \n", channelNo, MaxChannels);
         opDisplay(opOutBuf);
+
         return;
         }
 
@@ -2051,6 +2108,7 @@ void opCmdLoadCards(bool help, char *cmdParams)
         {
         sprintf(opOutBuf, "    > Invalid equipment no %02o. (must be 0 to %02o) \n", equipmentNo, MaxEquipment);
         opDisplay(opOutBuf);
+
         return;
         }
 
@@ -2100,6 +2158,7 @@ void opCmdLoadCards(bool help, char *cmdParams)
         {
         sprintf(opOutBuf, "    > Failed to create temporary card deck '%s'\n", newDeck);
         opDisplay(opOutBuf);
+
         return;
         }
 
@@ -2125,6 +2184,7 @@ void opCmdLoadCards(bool help, char *cmdParams)
         {
         sprintf(opOutBuf, "    > Error learning status of file '%s' (%s)\n", newDeck, strerror(errno));
         opDisplay(opOutBuf);
+
         return;
         }
     if (statBuf.st_size == 0)
@@ -2193,7 +2253,7 @@ static void opInterpolateParam(char **srcp, char **dstp, int argc, char *argv[])
             {
             sp += 1;
             }
-        dfltValLen = sp - dfltVal;
+        dfltValLen = (int)(sp - dfltVal);
         }
     if (*sp == '}')
         {
@@ -2240,7 +2300,6 @@ static void opInterpolateProp(char **srcp, char **dstp, char *srcPath)
     char *cp;
     char *dfltVal;
     int  dfltValLen;
-    char delim;
     char *dp;
     FILE *fp;
     char *pp;
@@ -2273,8 +2332,8 @@ static void opInterpolateProp(char **srcp, char **dstp, char *srcPath)
             *pp++ = *sp++;
             }
         }
-    *pp = '\0';
-    sectionNameLen = pp - sectionName;
+    *pp            = '\0';
+    sectionNameLen = (int)(pp - sectionName);
 
     pp = propName;
     if (*sp == ':')
@@ -2289,13 +2348,16 @@ static void opInterpolateProp(char **srcp, char **dstp, char *srcPath)
 
     if (*sp == ':')
         {
-        sp += 1;
+        sp     += 1;
         dfltVal = sp;
-        while (*sp != '}' && *sp != '\0') sp += 1;
-        dfltValLen = sp - dfltVal;
+        while (*sp != '}' && *sp != '\0')
+            {
+            sp += 1;
+            }
+        dfltValLen = (int)(sp - dfltVal);
         }
-    
-    if (*sp == '}' && propName[0] != '\0' && sectionName[0] != '\0' && propFilePath[0] != '\0')
+
+    if ((*sp == '}') && (propName[0] != '\0') && (sectionName[0] != '\0') && (propFilePath[0] != '\0'))
         {
         *srcp = sp + 1;
 #if defined(_WIN32)
@@ -2310,7 +2372,7 @@ static void opInterpolateProp(char **srcp, char **dstp, char *srcPath)
                 *cp = '\0';
                 sprintf(propFilePath2, "%s/%s", srcPath, propFilePath);
                 *cp = '/';
-                pp = propFilePath2;
+                pp  = propFilePath2;
                 }
             }
         fp = fopen(pp, "r");
@@ -2323,10 +2385,16 @@ static void opInterpolateProp(char **srcp, char **dstp, char *srcPath)
             while (TRUE)
                 {
                 sp = fgets(sbuf, sizeof(sbuf), fp);
-                if (sp == NULL) break;
-                if (*sp == '['
-                    && memcmp(sp + 1, sectionName, sectionNameLen) == 0
-                    && *(sp + sectionNameLen + 1) == ']') break;
+                if (sp == NULL)
+                    {
+                    break;
+                    }
+                if ((*sp == '[')
+                    && (memcmp(sp + 1, sectionName, sectionNameLen) == 0)
+                    && (*(sp + sectionNameLen + 1) == ']'))
+                    {
+                    break;
+                    }
                 }
             if (sp != NULL) // named section found
                 {
@@ -2336,9 +2404,15 @@ static void opInterpolateProp(char **srcp, char **dstp, char *srcPath)
                 while (TRUE)
                     {
                     sp = fgets(sbuf, sizeof(sbuf), fp);
-                    if (sp == NULL || *sp == '[') break;
+                    if ((sp == NULL) || (*sp == '['))
+                        {
+                        break;
+                        }
                     cp = strchr(sp, '=');
-                    if (cp == NULL) continue;
+                    if (cp == NULL)
+                        {
+                        continue;
+                        }
                     *cp++ = '\0';
                     if (strcmp(propName, sp) == 0)
                         {
@@ -2348,6 +2422,7 @@ static void opInterpolateProp(char **srcp, char **dstp, char *srcPath)
                             }
                         *dstp = dp;
                         fclose(fp);
+
                         return;
                         }
                     }
@@ -2363,6 +2438,7 @@ static void opInterpolateProp(char **srcp, char **dstp, char *srcPath)
             *dp++ = *dfltVal++;
             }
         *dstp = dp;
+
         return;
         }
 
@@ -2448,6 +2524,7 @@ static int opPrepCards(char *str, FILE *fcb)
         {
         sprintf(opOutBuf, "    > Failed to open %s\n", path);
         opDisplay(opOutBuf);
+
         return -1;
         }
     while (TRUE)
@@ -2763,7 +2840,7 @@ static void opCmdShowState(bool help, char *cmdParams)
         return;
         }
 
-    cpMask = (cpuCount >  1) ? 0x03 : 0x01;
+    cpMask = (cpuCount > 1) ? 0x03 : 0x01;
     ppMask = (ppuCount > 10) ? 0xfffff : 0x3ff;
     if (strlen(cmdParams) > 0)
         {
@@ -2788,11 +2865,12 @@ static void opCmdShowState(bool help, char *cmdParams)
                     {
                     if (*(param + 2) == '\0')
                         {
-                        cpMask = (cpuCount >  1) ? 0x03 : 0x01;
+                        cpMask = (cpuCount > 1) ? 0x03 : 0x01;
                         }
                     else
                         {
                         opDisplay("    > Missing or invalid CPU number\n");
+
                         return;
                         }
                     }
@@ -2850,9 +2928,9 @@ static void opCmdShowState(bool help, char *cmdParams)
 
 static void opCmdShowStateCP(u8 cpMask)
     {
-    u8 cpNum;
+    u8         cpNum;
     CpuContext *cpu;
-    int i;
+    int        i;
 
     cpMask |= (1 << 2); // stopper
     cpNum   = 0;
@@ -2877,7 +2955,7 @@ static void opCmdShowStateCP(u8 cpMask)
             opDisplay("    > ---------------- CPU ---------------\n");
             }
         cpu = cpus + cpNum;
-        i = 0;
+        i   = 0;
         sprintf(opOutBuf, "    > P       %06o  A%d %06o  B%d %06o\n", cpu->regP, i, cpu->regA[i], i, cpu->regB[i]);
         opDisplay(opOutBuf);
         i++;
@@ -2964,7 +3042,7 @@ static void opCmdShowStatePP(u32 ppMask)
             {
             pp = &ppu[i++];
             sprintf(buf, "P %04o", pp->regP);
-            len = strlen(buf);
+            len = (int)strlen(buf);
             while (len < 16)
                 {
                 buf[len++] = ' ';
@@ -2990,7 +3068,7 @@ static void opCmdShowStatePP(u32 ppMask)
             {
             pp = &ppu[i++];
             sprintf(buf, "A %06o", pp->regA);
-            len = strlen(buf);
+            len = (int)strlen(buf);
             while (len < 16)
                 {
                 buf[len++] = ' ';
@@ -3017,7 +3095,7 @@ static void opCmdShowStatePP(u32 ppMask)
             {
             pp = &ppu[i++];
             sprintf(buf, "Q %04o", pp->regQ);
-            len = strlen(buf);
+            len = (int)strlen(buf);
             while (len < 16)
                 {
                 buf[len++] = ' ';
@@ -3053,7 +3131,7 @@ static void opCmdShowStatePP(u32 ppMask)
                     {
                     sprintf(buf, "R %010o", pp->regR);
                     }
-                len = strlen(buf);
+                len = (int)strlen(buf);
                 while (len < 16)
                     {
                     buf[len++] = ' ';
@@ -3364,7 +3442,7 @@ static void opHelpShowEquipment(void)
 static void opCmdShowNetwork(bool help, char *cmdParams)
     {
     OpNetTypeEntry *entry;
-    char *token;
+    char           *token;
 
     /*
     **  Process help request.
@@ -3388,16 +3466,20 @@ static void opCmdShowNetwork(bool help, char *cmdParams)
         for (token = strtok(cmdParams, ", "); token != NULL; token = strtok(NULL, ", "))
             {
             for (entry = netTypes; entry->name != NULL && strcasecmp(token, entry->name) != 0; entry++)
-                ;
+                {
+                }
             if (entry->name != NULL)
                 {
                 if (entry->handler != NULL)
+                    {
                     (*entry->handler)();
+                    }
                 }
             else
                 {
                 sprintf(opOutBuf, "    > Unrecognized network type: %s\n", token);
                 opDisplay(opOutBuf);
+
                 return;
                 }
             }
@@ -3407,7 +3489,9 @@ static void opCmdShowNetwork(bool help, char *cmdParams)
         for (entry = netTypes; entry->name != NULL; entry++)
             {
             if (entry->handler != NULL)
+                {
                 (*entry->handler)();
+                }
             }
         }
     }
@@ -3420,7 +3504,10 @@ static void opHelpShowNetwork(void)
     opDisplay("    >    <net-type> : ");
     for (entry = netTypes; entry->name != NULL; entry++)
         {
-        if (entry != netTypes) opDisplay(" | ");
+        if (entry != netTypes)
+            {
+            opDisplay(" | ");
+            }
         opDisplay(entry->name);
         }
     opDisplay("\n");
@@ -3581,13 +3668,14 @@ static void opCmdIdle(bool help, char *cmdParams)
 
         return;
         }
-    if (*cmdParams == 'B' || *cmdParams == 'b')
+    if ((*cmdParams == 'B') || (*cmdParams == 'b'))
         {
         numParam = sscanf(cmdParams + 1, "%u", &newThreshold);
         if (numParam < 1)
             {
             sprintf(opOutBuf, "    > Buffer count missing\n");
             opDisplay(opOutBuf);
+
             return;
             }
         idleNetBufs = newThreshold;
@@ -3602,12 +3690,14 @@ static void opCmdIdle(bool help, char *cmdParams)
             {
             sprintf(opOutBuf, "    > 2 parameters expected - %u provided\n", numParam);
             opDisplay(opOutBuf);
+
             return;
             }
         if ((newTrigger < 1) || (newSleep < 1))
             {
             sprintf(opOutBuf, "    > No parameters provided (1 or 2 expected)\n");
             opDisplay(opOutBuf);
+
             return;
             }
         idleTrigger = (u32)newTrigger;
@@ -3714,17 +3804,23 @@ static void opHelpStopHelpers(void)
 static void opDisplayVersion(void)
     {
     opDisplay("\n--------------------------------------------------------------------------------");
-    sprintf(opOutBuf, "\n     %s", DtCyberVersion); opDisplay(opOutBuf);
-    sprintf(opOutBuf, "\n     %s", DtCyberCopyright); opDisplay(opOutBuf);
-    sprintf(opOutBuf, "\n     %s", DtCyberLicense); opDisplay(opOutBuf);
-    sprintf(opOutBuf, "\n     %s", DtCyberLicenseDetails); opDisplay(opOutBuf);
+    sprintf(opOutBuf, "\n     %s", DtCyberVersion);
+    opDisplay(opOutBuf);
+    sprintf(opOutBuf, "\n     %s", DtCyberCopyright);
+    opDisplay(opOutBuf);
+    sprintf(opOutBuf, "\n     %s", DtCyberLicense);
+    opDisplay(opOutBuf);
+    sprintf(opOutBuf, "\n     %s", DtCyberLicenseDetails);
+    opDisplay(opOutBuf);
     opDisplay("\n--------------------------------------------------------------------------------");
-    sprintf(opOutBuf, "\n     Build date: %s", DtCyberBuildDate); opDisplay(opOutBuf);
+    sprintf(opOutBuf, "\n     Build date: %s", DtCyberBuildDate);
+    opDisplay(opOutBuf);
     opDisplay("\n--------------------------------------------------------------------------------");
     opDisplay("\n");
     }
 
 #if defined(_WIN32)
+
 /*--------------------------------------------------------------------------
 **  Purpose:        Translate a Windows-style pathname to a Unix-style one
 **
@@ -3740,9 +3836,13 @@ static void opToUnixPath(char *path)
 
     for (cp = path; *cp != '\0'; cp++)
         {
-        if (*cp == '\\') *cp = '/';
+        if (*cp == '\\')
+            {
+            *cp = '/';
+            }
         }
     }
+
 #endif
 
 /*---------------------------  End Of File  ------------------------------*/

--- a/pci_channel_linux.c
+++ b/pci_channel_linux.c
@@ -178,14 +178,14 @@ void pciInit(u8 eqNo, u8 unitNo, u8 channelNo, char *deviceName)
     pci = calloc(1, sizeof(PciParam));
     if (pci == NULL)
         {
-        fprintf(stderr, "Failed to allocate PCI channel context block\n");
+        logDtError(LogErrorLocation, "Failed to allocate PCI channel context block\n");
         exit(1);
         }
 
     pci->fdPci = open(DEVICE_NODE, 0);
     if (pci->fdPci < 0)
         {
-        fprintf(stderr, "Can't open %s - error %s\n", DEVICE_NODE, strerror(errno));
+        logDtError(LogErrorLocation, "Can't open %s - error %s\n", DEVICE_NODE, strerror(errno));
         exit(1);
         }
 

--- a/pci_channel_win32.c
+++ b/pci_channel_win32.c
@@ -175,14 +175,14 @@ void pciInit(u8 eqNo, u8 unitNo, u8 channelNo, char *deviceName)
     pci = calloc(1, sizeof(PciParam));
     if (pci == NULL)
         {
-        fprintf(stderr, "(pci_channel_win32) Failed to allocate PCI channel context block\n");
+        logDtError(LogErrorLocation, "(pci_channel_win32) Failed to allocate PCI channel context block\n");
         exit(1);
         }
 
     retValue = GetDeviceHandle();
     if (!retValue)
         {
-        fprintf(stderr, "(pci_channel_win32) Can't open CYBER channel interface.\n");
+        logDtError(LogErrorLocation, "(pci_channel_win32) Can't open CYBER channel interface.\n");
         exit(1);
         }
 

--- a/pci_console_linux.c
+++ b/pci_console_linux.c
@@ -215,14 +215,14 @@ void pciConsoleInit(u8 eqNo, u8 unitNo, u8 channelNo, char *deviceName)
     pci = calloc(1, sizeof(PciParam));
     if (pci == NULL)
         {
-        fprintf(stderr, "Failed to allocate PCI channel context block\n");
+        logDtError(LogErrorLocation, "Failed to allocate PCI channel context block\n");
         exit(1);
         }
 
     pci->fdPci = open(DEVICE_NODE, 0);
     if (pci->fdPci < 0)
         {
-        fprintf(stderr, "Can't open %s - error %s\n", DEVICE_NODE, strerror(errno));
+        logDtError(LogErrorLocation, "Can't open %s - error %s\n", DEVICE_NODE, strerror(errno));
         exit(1);
         }
 

--- a/rtc.c
+++ b/rtc.c
@@ -291,10 +291,10 @@ void rtcReadUsCounter(void)
 
 void rtcReadUsCounter(void)
     {
-    static bool   first = TRUE;
-    static u64    old   = 0;
-    u64           new;
-    u64           difference;
+    static bool first = TRUE;
+    static u64  old   = 0;
+    u64         new;
+    u64         difference;
 
     if (rtcIncrement != 0)
         {
@@ -318,12 +318,12 @@ void rtcReadUsCounter(void)
     difference = new - old;
     if (difference > MaxMicroseconds)
         {
-        difference = MaxMicroseconds;
-        rtcClockIsCurrent   = FALSE;
+        difference        = MaxMicroseconds;
+        rtcClockIsCurrent = FALSE;
         }
     else
         {
-        rtcClockIsCurrent   = TRUE;
+        rtcClockIsCurrent = TRUE;
         }
 
     old      += difference;

--- a/scr_channel.c
+++ b/scr_channel.c
@@ -304,7 +304,7 @@ static void scrExecute(PpWord func)
             **  Select appropriate CM configuration quadrants.
             */
             switch (cpuMaxMemory)
-            {
+                {
             case 01000000:
                 scrSetBit(scrRegister, 0260);
                 scrClrBit(scrRegister, 0261);
@@ -370,7 +370,7 @@ static void scrExecute(PpWord func)
                 scrClrBit(scrRegister, 0262);
                 scrClrBit(scrRegister, 0263);
                 break;
-            }
+                }
             }
 
         break;

--- a/scr_channel.c
+++ b/scr_channel.c
@@ -128,7 +128,7 @@ void scrInit(u8 channelNo)
     dp->context[0] = calloc(StatusAndControlWords, sizeof(PpWord));
     if (dp->context[0] == NULL)
         {
-        fprintf(stderr, "(scr_channel) Failed to allocate Status/Control Register context block\n");
+        logDtError(LogErrorLocation, "Failed to allocate Status/Control Register context block\n");
         exit(1);
         }
 

--- a/time.c
+++ b/time.c
@@ -129,3 +129,5 @@ void sleepUsec(u64 usec)
     nanosleep(&ts, &ts);
 #endif
     }
+
+/*---------------------------  End Of File  ------------------------------*/

--- a/trace.c
+++ b/trace.c
@@ -344,14 +344,14 @@ void traceInit(void)
     devF = fopen("device.trc", "wt");
     if (devF == NULL)
         {
-        fprintf(stderr, "(trace  ) can't open device.trc - aborting\n");
+        logDtError(LogErrorLocation, "Can't open device.trc - aborting\n");
         exit(1);
         }
 
     cpuF = calloc(cpuCount, sizeof(FILE *));
     if (cpuF == NULL)
         {
-        fprintf(stderr, "(trace  ) Failed to allocate CPU trace FILE pointers - aborting\n");
+        logDtError(LogErrorLocation, "Failed to allocate CPU trace FILE pointers - aborting\n");
         exit(1);
         }
     for (cp = 0; cp < cpuCount; cp++)
@@ -360,7 +360,7 @@ void traceInit(void)
         cpuF[cp] = fopen(fileName, "wt");
         if (cpuF[cp] == NULL)
             {
-            fprintf(stderr, "(trace  ) Can't open cpu[%o] trace (%s) - aborting\n", cp, fileName);
+            logDtError(LogErrorLocation, "Can't open cpu[%o] trace (%s) - aborting\n", cp, fileName);
             exit(1);
             }
         }
@@ -368,7 +368,7 @@ void traceInit(void)
     ppuF = calloc(ppuCount, sizeof(FILE *));
     if (ppuF == NULL)
         {
-        fprintf(stderr, "(trace  ) Failed to allocate PP trace FILE pointers - aborting\n");
+        logDtError(LogErrorLocation, "Failed to allocate PP trace FILE pointers - aborting\n");
         exit(1);
         }
 
@@ -378,7 +378,7 @@ void traceInit(void)
         ppuF[pp] = fopen(fileName, "wt");
         if (ppuF[pp] == NULL)
             {
-            fprintf(stderr, "(trace  ) Can't open ppu[%02o] trace (%s) - aborting\n", pp, fileName);
+            logDtError(LogErrorLocation, "Can't open ppu[%02o] trace (%s) - aborting\n", pp, fileName);
             exit(1);
             }
         }

--- a/types.h
+++ b/types.h
@@ -241,6 +241,7 @@ typedef struct
     u8            opK;                  /* K field (first 3 bits only) */
     u32           opAddress;            /* K field (18 bits) */
     bool          floatException;       /* TRUE if CPU detected float exception */
+
     /*
     **  Instruction word stack.
     */
@@ -248,7 +249,7 @@ typedef struct
     u32           iwAddress[MaxIwStack];
     bool          iwValid[MaxIwStack];
     u8            iwRank;
-    volatile u32 idleCycles;            /* Counter for how many times we've seen the idle loop */
+    volatile u32  idleCycles;           /* Counter for how many times we've seen the idle loop */
     } CpuContext;
 
 /*
@@ -297,8 +298,8 @@ typedef enum
     ESM
     } ExtMemory;
 
-typedef enum 
-    {   
+typedef enum
+    {
     SwCCP = 0,
     SwCCI,
     SwUndefined

--- a/window_win32.c
+++ b/window_win32.c
@@ -599,7 +599,7 @@ static LRESULT CALLBACK windowProcedure(HWND hWnd, UINT message, WPARAM wParam, 
         if (GetKeyState(VK_CONTROL) & 0x8000)
             {
             switch (wParam)
-            {
+                {
             case '0':
             case '1':
             case '2':
@@ -617,7 +617,7 @@ static LRESULT CALLBACK windowProcedure(HWND hWnd, UINT message, WPARAM wParam, 
             case 'c':
                 dumpRunningCpu();
                 break;
-            }
+                }
             }
 
         break;
@@ -631,7 +631,7 @@ static LRESULT CALLBACK windowProcedure(HWND hWnd, UINT message, WPARAM wParam, 
      */
     case WM_SYSCHAR:
         switch (wParam)
-        {
+            {
         case '0':
         case '1':
         case '2':
@@ -701,7 +701,7 @@ static LRESULT CALLBACK windowProcedure(HWND hWnd, UINT message, WPARAM wParam, 
         case 's':
         case 'S':
             shifted = !shifted;
-        }
+            }
         break;
 
     case WM_CHAR:

--- a/window_x11.c
+++ b/window_x11.c
@@ -507,7 +507,7 @@ void *windowThread(void *param)
                     else
                         {
                         switch (text[0])
-                        {
+                            {
                         case '0':
                         case '1':
                         case '2':
@@ -564,7 +564,7 @@ void *windowThread(void *param)
                             */
                             XConvertSelection(disp, XA_PRIMARY, XA_STRING, targetProperty, window, event.xbutton.time);
                             break;
-                        }
+                            }
                         ppKeyIn = 0;
                         }
                     }

--- a/window_x11.c
+++ b/window_x11.c
@@ -718,14 +718,17 @@ void *windowThread(void *param)
                 case FontSmall:
                     XSetFont(disp, gc, hSmallFont);
                     break;
+
                 case FontMedium:
                     XSetFont(disp, gc, hMediumFont);
                     break;
+
                 case FontLarge:
                     XSetFont(disp, gc, hLargeFont);
                     break;
                     }
                 }
+
             /*
             **  Draw dot or character.
             */


### PR DESCRIPTION
Code Cleanup (No platform specific modifications)

1) Full pass of "Uncrustify".  (Still need to look into why PP doesn't handle nested switch statements properly.  Manually cleaned them up in the second pass).

2) Reshape error logging throughout the codebase for writes directed at stderr such that all messages are logged to dtcyberlog.txt AND to the console window with module name and line number of message.   Sometimes, error messages scroll out of the too-shallow "window" display buffer or dtCyber will encounter an error and the window process aborts destroying the error trail.

3) Add Date and Time to the operator command prompt followed by newline to shorten the operator prompt a bit.

4) Remove the need to manually supply the module name when writing error messages to stderr. (Let the compiler do the work)

5) logDtError Adds the line number, date and time of the error being logged.  Individual diagnostic logging to separate files has been left alone.  

6) Clean up all warnings thrown by Visual Studio (MSVC) (primarily asymmetric types during assignment operations).

7) Clean up ambiguity warnings through by MSVC (mostly for 'if' conditions)