### PR TITLE
Introduce a delay to help ensure that tape drives are fully unloaded …

### DIFF
--- a/NOS2.8.7/make-ds-tape.js
+++ b/NOS2.8.7/make-ds-tape.js
@@ -14,6 +14,7 @@ dtc.connect()
   "[UNLOAD,51.",
   "[!"
 ]))
+.then(() => dtc.sleep(3000))
 .then(() => dtc.mount(13, 0, 0, "tapes/ds.tap"))
 .then(() => dtc.mount(13, 0, 1, "tapes/newds.tap", true))
 .then(() => dtc.sleep(5000))


### PR DESCRIPTION
…before attempting to mount new tapes